### PR TITLE
[WIP] Python 3 compatibility for root_numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 
 python:
   - "2.7"
-#  - "3.2"
+  - "3.2"
 
 env:
   - ROOT=5.34.03

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,19 @@ root_inc = ''
 root_ldflags = []
 try:
     root_inc = subprocess.Popen(["root-config", "--incdir"],
-                        stdout=subprocess.PIPE).communicate()[0].strip()
+                        stdout=subprocess.PIPE).communicate()[0]
+    root_inc = str(root_inc, encoding='utf8').strip()
     root_ldflags = subprocess.Popen(["root-config", "--libs"],
-                        stdout=subprocess.PIPE).communicate()[0].strip().split(' ')
+                        stdout=subprocess.PIPE).communicate()[0]
+    root_ldflags = str(root_ldflags, encoding='utf8').strip().split()
 except OSError:
     rootsys = os.environ['ROOTSYS']
     root_inc = subprocess.Popen([rootsys+"/bin/root-config", "--incdir"],
-                        stdout=subprocess.PIPE).communicate()[0].strip()
+                        stdout=subprocess.PIPE).communicate()[0]
+    root_inc = str(root_inc, encoding='utf8').strip()
     root_ldflags = subprocess.Popen([rootsys+"/bin/root-config", "--libs"],
-                        stdout=subprocess.PIPE).communicate()[0].strip().split(' ')
+                        stdout=subprocess.PIPE).communicate()[0]
+    root_ldflags = str(root_ldflags, encoding='utf8').strip().split()
 
 module = Extension('root_numpy._librootnumpy',
                    sources=['root_numpy/_librootnumpy.cpp'],


### PR DESCRIPTION
Attempting to add Python 3 compatibility to root_numpy while keeping Python 2 compatibility with a single code base, i.e. not using the `2to3` tool.

I created this branch off of the travis branch. Please merge https://github.com/rootpy/root_numpy/pull/12 first.