### PR TITLE
[WIP] Add hist2array and array2hist functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist
 root_numpy/_librootnumpy.html
 *.d
 _build
+.Rhistory
+.project
+.pydevproject

--- a/root_numpy/hist.py
+++ b/root_numpy/hist.py
@@ -11,19 +11,6 @@ def _get_hist_dtype(hist):
                     ''.format(dim, hist_dtype)):
                 return hist_dtype
 
-def _get_hist_ndim(hist):
-    """Determine the number of dimensions for a ROOT hist"""
-    # Note that the order is important here, because
-    # ROOT.TH3 is a ROOT.TH1
-    if isinstance(hist, ROOT.TH3):
-        return 3
-    elif isinstance(hist, ROOT.TH2):
-        return 2
-    elif isinstance(hist, ROOT.TH1):
-        return 1
-    else:
-        raise TypeError("Can't process type: {0}".format(type(hist)))
-    
 
 def _get_numpy_dtype(hist):
     """Determine the corresponding numpy dtype for a given ROOT hist"""
@@ -122,7 +109,7 @@ def fill_hist_from_array(hist, array, weights=None):
     If you have (x, y) separately, ypu can use array = np.vstack([x, y])
     when calling this function.
     """
-    ndim = _get_hist_ndim(hist)
+    ndim = hist.GetDimension()
 
     array = np.asarray(array, dtype='float64')
 

--- a/root_numpy/hist.py
+++ b/root_numpy/hist.py
@@ -1,0 +1,176 @@
+"""Efficient functions for working with ROOT histograms and numpy arrays""" 
+import numpy as np
+import ROOT
+
+
+def _get_hist_dtype(hist):
+    """Determine the hist_dtype for a ROOT hist"""
+    for dim in [1, 2, 3]:
+        for hist_dtype in 'C S I F D'.split():
+            if eval('isinstance(hist, ROOT.TH{0}{1})'
+                    ''.format(dim, hist_dtype)):
+                return hist_dtype
+
+def _get_hist_ndim(hist):
+    """Determine the number of dimensions for a ROOT hist"""
+    # Note that the order is important here, because
+    # ROOT.TH3 is a ROOT.TH1
+    if isinstance(hist, ROOT.TH3):
+        return 3
+    elif isinstance(hist, ROOT.TH2):
+        return 2
+    elif isinstance(hist, ROOT.TH1):
+        return 1
+    else:
+        raise TypeError("Can't process type: {0}".format(type(hist)))
+    
+
+def _get_numpy_dtype(hist):
+    """Determine the corresponding numpy dtype for a given ROOT hist"""
+    hist_dtype = _get_hist_dtype(hist)
+    d = dict(C='u1', S='i2', I='i4', F='f4', D='f8')
+    return np.dtype(d[hist_dtype])
+
+
+
+def hist2array(hist, include_overflow=False):
+    """Convert a ROOT histogram into a numpy array
+
+    Parameters
+    -----------
+    hist : `~ROOT.TH` histogram (1-, 2- or 3-dimensional)
+
+    include_overflow : bool, optional
+        If True, the over- and underflow bins will be included in the
+        output numpy array
+
+    Returns
+    -------
+    array : `~numpy.ndarray`
+        Numpy array containing the histogram bin values
+    """
+
+    if isinstance(hist, ROOT.TH3):
+        shape = (hist.GetNbinsZ(), hist.GetNbinsY(), hist.GetNbinsX())
+    elif isinstance(hist, ROOT.TH2):
+        shape = (hist.GetNbinsY(), hist.GetNbinsX())
+    elif isinstance(hist, ROOT.TH1):
+        shape = (hist.GetNbinsX(),)
+    else:
+        raise TypeError("Can't process type: %s" % type(hist))
+
+    # ROOT.TH array always includes the over- and underflow bins
+    shape = [_ + 2 for _ in shape]
+    dtype = _get_numpy_dtype(hist)
+    array = np.ndarray(shape=shape, dtype=dtype, buffer=hist.GetArray())
+
+    if not include_overflow:
+        # remove overflow and underflow bins
+        if array.ndim == 1:
+            array = array[1:-1]
+        elif array.ndim == 2:
+            array = array[1:-1, 1:-1]
+        elif array.ndim == 3:
+            array = array[1:-1, 1:-1, 1:-1]
+            
+    return array
+
+
+def array2hist(array, has_overflow=False):
+    """Convert a numpy array into a ROOT histogram
+
+    Parameters
+    -----------
+    array : `~numpy.ndarray`
+        Numpy array (1-, 2- or 3-dimensional)
+
+    include_overflow : bool, optional
+        If True, the input numpy array is assumed to contain
+        over- and underflow bins.
+
+    Returns
+    -------
+    hist : `~ROOT.TH` histogram
+    """
+
+    raise NotImplementedError
+    """
+    array = np.asarray(array)
+    import ctypes
+    NULL_DOUBLE_P = ctypes.POINTER(ctypes.c_double)()
+    memmove()
+    """
+
+
+def fill_hist_from_array(hist, array, weights=None):
+    """Fill a ROOT histogram from a numpy array
+
+    Parameters
+    -----------
+    hist : `~ROOT.TH` histogram (1-, 2- or 3-dimensional)
+
+    array : `~numpy.ndarray`
+        2-dimensional numpy array
+        (number of columns must match the hist dimensionality)
+
+    weights : `~numpy.ndarray`
+        Numpy 1-dimensional array (same number of rows as `array`)
+
+    Notes
+    -----
+    
+    If you have (x, y) separately, ypu can use array = np.vstack([x, y])
+    when calling this function.
+    """
+    ndim = _get_hist_ndim(hist)
+
+    array = np.asarray(array, dtype='float64')
+
+    # check that array number of columns matches the hist dimensionality
+    if ndim == 3:
+        if array.ndim != 2:
+            raise ValueError('Hist is 3D. Array must be 2D, but is {0}D.'.format(array.ndim))
+        if array.shape[1] != 3:
+            raise ValueError('Hist is 3D. Array must have 3 columns, but has {0}'.format(array.shape[1]))
+    elif ndim == 2:
+        if array.ndim != 2:
+            raise ValueError('Hist is 2D. Array must be 2D, but is {0}D.'.format(array.ndim))
+        if array.shape[1] != 2:
+            raise ValueError('Hist is 2D. Array must have 2 columns, but has {0}'.format(array.shape[1]))
+    elif ndim == 1:
+        if array.ndim != 1:
+            raise ValueError('Hist is 1D. Array must be 1D, but is {0}D.'.format(array.ndim))
+    else:
+        raise TypeError("Can't process type: {0}".format(type(hist)))
+
+    ntimes = array.shape[0]
+
+    # Check that weights are OK
+    if weights is not None:
+        weights = np.asarray(weights, dtype='float64')
+        if weights.shape !=  ntimes:
+            raise ValueError("array shape %s and weights shape %s do not match." %
+                             (ntimes, weights.shape))
+    else:
+        weights = np.ones(ntimes, dtype='float64')
+
+    # Fill the hist; hist.FillN takes x, y, z
+    if ndim == 1:
+        hist.FillN(ntimes, array, weights)
+    elif ndim == 2:
+        x, y = array[:,0].copy(), array[:,1].copy()
+        # C++ method signature:
+        # void TH2::FillN(Int_t, const Double_t*, const Double_t*, Int_t)
+        # void TH2::FillN(Int_t ntimes, const Double_t* x, const Double_t* y, const Double_t* w, Int_t stride = 1)
+        hist.FillN(ntimes, x, y, weights)
+    elif ndim == 3:
+        x, y, z = array[:,0].copy(), array[:,1].copy(), array[:,2].copy()
+        # import IPython; IPython.embed(); 1/0
+        raise NotImplementedError
+        # This doesn't work because there is no TH3::FillN
+        # C++ method signature:
+        # void TH1::FillN(Int_t ntimes, const Double_t* x, const Double_t* w, Int_t stride = 1)
+        # void TH1::FillN(Int_t, const Double_t*, const Double_t*, const Double_t*, Int_t)
+        hist.FillN(ntimes, x, y, z, weights)
+    else:
+        raise ValueError("Can't handle histograms of dimension {0}.".format(ntimes))

--- a/root_numpy/tests/test_hist.py
+++ b/root_numpy/tests/test_hist.py
@@ -1,0 +1,92 @@
+import unittest
+import itertools
+import numpy as np
+from numpy.testing import assert_equal, assert_array_equal, assert_raises
+import ROOT
+from root_numpy.hist import hist2array, array2hist, fill_hist_from_array
+
+def _get_hist(dim, hist_class):
+    if dim == 1:
+        return hist_class('hist', 'hist', 5, 0, 1)
+    elif dim == 2:
+        return hist_class('hist', 'hist', 5, 0, 1, 6, 0, 2)
+    elif dim == 3:
+        return hist_class('hist', 'hist', 5, 0, 1, 6, 0, 2, 7, 0, 3)
+
+class TestHist2Array(unittest.TestCase):
+    # List of ROOT hist types taken from
+    # http://root.cern.ch/root/html/TH1.html
+    dims = [1, 2, 3]
+    # TODO: for hist_dtype = 'C' I get this error:
+    # TypeError: buffer is too small for requested array
+    hist_dtypes = 'S I F D'.split()
+    #hists = [(dim, type, eval('ROOT.TH{0}{1}'.format(dim, type)))
+    #         for (dim, type) in itertools.product(dims, dtypes)] 
+
+    def test_all(self):
+        for dim in self.dims: 
+            for hist_dtype in self.hist_dtypes:
+                hist_class = eval('ROOT.TH{0}{1}'.format(dim, hist_dtype))
+                hist = _get_hist(dim, hist_class)
+                array = hist2array(hist)
+                # hist was initialized to zero, and summing zeros gives zero:
+                assert_equal(np.sum(np.abs(array)), 0)
+
+    def test_invalid_inputs(self):
+        """Check that input we can't handle raises a proper exception"""
+        input1 = ROOT.THnD()
+        assert_raises(TypeError, hist2array, input1)
+
+class TestArray2HistRountTripping(unittest.TestCase):
+
+    numpy_dtypes = 'b i1 u1 i2 u2 i4 u4 i8 u8 f4 f8'
+
+    def _test_all(self):
+        for shape in [5, (5, 6), (5, 6, 7)]:
+            for numpy_dtype in numpy_dtypes:
+                array = np.random.random(5, dtype=numpy_dtype)
+                hist = array2hist(array)
+                array2 = hist2array(hist)
+                np.assert_array_equal(array, array2)
+
+
+class TestFillHistFromArray(unittest.TestCase):
+
+    # TODO: 3D case doesn't work for now
+    dims = [1, 2]
+    hist_dtypes = 'S I F D'.split()
+    numpy_dtypes = 'b i1 u1 i2 u2 i4 u4 i8 u8 f4 f8'.split()
+
+    def test_all(self):
+        nevents = 100
+        for dim in self.dims:
+            for hist_dtype in self.hist_dtypes:
+                for numpy_dtype in self.numpy_dtypes:
+                    hist_class = eval('ROOT.TH{0}{1}'.format(dim, hist_dtype))
+                    hist = _get_hist(dim, hist_class)
+                    array = np.ones(shape=(nevents, dim), dtype=numpy_dtype)
+                    if dim == 1:
+                        array = array.flatten()
+                    fill_hist_from_array(hist, array)
+                    #fill_hist_from_array(hist, array, weights=array)
+                    
+
+def _test_quickly():
+    from rootpy.plotting import Hist, Hist2D, Hist3D
+    #h1 = Hist(5, 0, 1, type='d')
+    h1 = ROOT.TH1S('h', 'h', 5, 0, 1)
+    h2 = Hist2D(5, 0, 1, 3, 0, 1, type='d')
+    h3 = Hist3D(5, 0, 1, 3, 0, 1, 2, 0, 1, type='d')
+    
+    fill_hist_from_array(h1, np.random.randn(1E6))
+    
+    print hist2array(h1)
+    print hist2array(h2)
+    print hist2array(h3)
+
+
+# TODO: Add more tests for invalid inputs and check that
+# the right exceptions are raised.
+
+if __name__ == '__main__':
+    unittest.main()

--- a/root_numpy/tests/test_hist.py
+++ b/root_numpy/tests/test_hist.py
@@ -1,3 +1,4 @@
+import uuid
 import unittest
 import itertools
 import numpy as np
@@ -6,12 +7,13 @@ import ROOT
 from root_numpy.hist import hist2array, array2hist, fill_hist_from_array
 
 def _get_hist(dim, hist_class):
+    name = uuid.uuid4().hex
     if dim == 1:
-        return hist_class('hist', 'hist', 5, 0, 1)
+        return hist_class(name, '', 5, 0, 1)
     elif dim == 2:
-        return hist_class('hist', 'hist', 5, 0, 1, 6, 0, 2)
+        return hist_class(name, '', 5, 0, 1, 6, 0, 2)
     elif dim == 3:
-        return hist_class('hist', 'hist', 5, 0, 1, 6, 0, 2, 7, 0, 3)
+        return hist_class(name, '', 5, 0, 1, 6, 0, 2, 7, 0, 3)
 
 class TestHist2Array(unittest.TestCase):
     # List of ROOT hist types taken from
@@ -34,8 +36,13 @@ class TestHist2Array(unittest.TestCase):
 
     def test_invalid_inputs(self):
         """Check that input we can't handle raises a proper exception"""
-        input1 = ROOT.THnD()
-        assert_raises(TypeError, hist2array, input1)
+        inputs = []
+        # Apparently THnD is not there in ROOT 5.32:
+        inputs.append(ROOT.THnD())
+        inputs.append(42)
+        inputs.append(np.arange(10))
+        for input in inputs:
+            assert_raises(TypeError, hist2array, input)
 
 class TestArray2HistRountTripping(unittest.TestCase):
 

--- a/root_numpy/tests/test_hist.py
+++ b/root_numpy/tests/test_hist.py
@@ -38,7 +38,7 @@ class TestHist2Array(unittest.TestCase):
         """Check that input we can't handle raises a proper exception"""
         inputs = []
         # Apparently THnD is not there in ROOT 5.32:
-        inputs.append(ROOT.THnD())
+        # inputs.append(ROOT.THnD())
         inputs.append(42)
         inputs.append(np.arange(10))
         for input in inputs:


### PR DESCRIPTION
This feature was originally discussed here:
https://github.com/rootpy/rootpy/issues/24

Since it explicitly uses numpy, it is better located in `root_numpy`.

The following things should be done before merging this PR:
* Implement `array2hist`. Anyone has an idea how / if this works with Python only?
* Add to tutorial documentation
* Add more unit tests
* Add speed / memory benchmark
