### PR TITLE
check if root was build with c++11, if so, build root_numpy with c++11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,13 @@ except OSError:
             "ROOTSYS is {0} but running {1} failed".format(
                 rootsys, root_config))
 
+librootnumpy_comp_args =  ['-Wno-unused-function']
+
+root_cflags = str(subprocess.Popen(["root-config", "--cflags"],
+                                   stdout=subprocess.PIPE).communicate()[0])
+if "-std=c++11" in root_cflags:
+    librootnumpy_comp_args.append("-std=c++11")
+
 librootnumpy = Extension('root_numpy._librootnumpy',
     sources=[
         'root_numpy/src/_librootnumpy.cpp',
@@ -70,7 +77,7 @@ librootnumpy = Extension('root_numpy._librootnumpy',
         np.get_include(),
         root_inc,
         'root_numpy/src'],
-    extra_compile_args=['-Wno-unused-function'],
+    extra_compile_args=librootnumpy_comp_args,
     extra_link_args=root_ldflags + ['-lTreePlayer'])
 
 # check for custom args


### PR DESCRIPTION
I added a call to `root-config --cflags` to check if root was build with c++11 features and if this is the case `-std=c++11` is added to the `extra-compile-args`  for librootnumpy.