### PR TITLE
[MRG] Huge speed improvement for trees with many branches

### DIFF
--- a/root_numpy/tests.py
+++ b/root_numpy/tests.py
@@ -271,16 +271,6 @@ def test_object_expression():
             np.arange(10, dtype='d') + 2]))
 
 
-def test_branch_status():
-    # test that original branch status is preserved
-    chain = TChain('tree')
-    chain.Add(load('single1.root'))
-    chain.Add(load('single2.root'))
-    chain.SetBranchStatus('d_double', False)
-    a = rnp.tree2rec(chain, selection="d_double > 100")
-    assert_equal(chain.GetBranchStatus('d_double'), False)
-
-
 @raises(ValueError)
 def test_branch_DNE():
     chain = TChain('tree')


### PR DESCRIPTION
Don't bother remember and revert to original branch status, and avoid the slow SetBranchStatus.

Tested on a tree with 2256 branches.

Before:
```python
>>> min(timeit.Timer("rnp.tree2array(t, branches=branches)", setup=setup).repeat(10, 1))
14.4979131222
```

After:
```python
>>> min(timeit.Timer("rnp.tree2array(t, branches=branches)", setup=setup).repeat(10, 1))
0.362231016159
```