### PR TITLE
[MRG] warn_missing_tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ clean: clean-build clean-pyc clean-so
 
 cython: $(CYTHON_CORE_CPP) $(CYTHON_TMVA_CPP)
 
+clean-cython:
+	@rm -f $(CYTHON_CORE_CPP)
+	@rm -f $(CYTHON_TMVA_CPP)
+
 show-cython: clean-html
 	@tmp=`mktemp -d`; \
 	for pyx in $(CYTHON_PYX_SRC); do \

--- a/root_numpy/_tree.py
+++ b/root_numpy/_tree.py
@@ -102,7 +102,8 @@ def root2array(filenames,
                step=None,
                include_weight=False,
                weight_name='weight',
-               cache_size=-1):
+               cache_size=-1,
+               warn_missing_tree=False):
     """Convert trees in ROOT files into a numpy structured array.
 
     Parameters
@@ -133,6 +134,9 @@ def root2array(filenames,
         Set the size (in bytes) of the TTreeCache used while reading a TTree. A
         value of -1 uses ROOT's default cache size. A value of 0 disables the
         cache.
+    warn_missing_tree : bool, optional (default=False)
+        If True, then warn when a tree is missing from an input file instead of
+        raising an IOError.
 
     Notes
     -----
@@ -172,7 +176,8 @@ def root2array(filenames,
         start, stop, step,
         include_weight,
         weight_name,
-        cache_size)
+        cache_size,
+        warn_missing_tree)
 
     if flatten:
         # select single column
@@ -189,7 +194,8 @@ def root2rec(filenames,
              step=None,
              include_weight=False,
              weight_name='weight',
-             cache_size=-1):
+             cache_size=-1,
+             warn_missing_tree=False):
     """View the result of :func:`root2array` as a record array.
 
     Notes
@@ -210,7 +216,8 @@ def root2rec(filenames,
                       start, stop, step,
                       include_weight,
                       weight_name,
-                      cache_size).view(np.recarray)
+                      cache_size,
+                      warn_missing_tree).view(np.recarray)
 
 
 def tree2array(tree,

--- a/root_numpy/src/ROOT.pxi
+++ b/root_numpy/src/ROOT.pxi
@@ -82,6 +82,7 @@ cdef extern from "TChain.h":
         TChain(const_char*)
         int Add(const_char*, long_long)
         void Print()
+        int GetNtrees()
 
 cdef extern from "TFormula.h":
     cdef cppclass TFormula:

--- a/root_numpy/src/TreeChain.h
+++ b/root_numpy/src/TreeChain.h
@@ -43,8 +43,9 @@ class TreeChain
 {
     public:
 
-    TreeChain(TTree* tree, long long cache_size):
+    TreeChain(TTree* tree, bool ischain, long long cache_size):
         tree(tree),
+        ischain(ischain),
         itree(-1),
         ientry(0),
         cache_size(cache_size)
@@ -261,8 +262,12 @@ class TreeChain
             branch = tree->FindBranch(bname.c_str());
             if (branch == NULL)
             {
-                std::cerr << "WARNING: cannot find branch " << bname
-                          << std::endl;
+                std::cerr << "WARNING: cannot find branch " << bname;
+                if (ischain)
+                {
+                    std::cerr << " in file " << ((TChain*) tree)->GetFile()->GetName();
+                }
+                std::cerr << std::endl;
                 continue;
             }
             leaf = branch->FindLeaf(lname.c_str());
@@ -325,6 +330,7 @@ class TreeChain
     };
 
     TTree* tree;
+    bool ischain;
     int itree;
     long long ientry;
     long long cache_size;

--- a/root_numpy/src/_librootnumpy.cpp
+++ b/root_numpy/src/_librootnumpy.cpp
@@ -1453,7 +1453,7 @@ struct __pyx_opt_args_13_librootnumpy_handle_load {
 #line 102 "root_numpy/src/tree.pyx"
 };
 
-/* "root_numpy/src/tree.pyx":401
+/* "root_numpy/src/tree.pyx":419
  * 
  * 
  * cdef TTree* array2tree(np.ndarray arr, string name='tree', TTree* tree=NULL) except *:             # <<<<<<<<<<<<<<
@@ -1461,19 +1461,19 @@ struct __pyx_opt_args_13_librootnumpy_handle_load {
  *     cdef NP2ROOTConverter* cvt
  */
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 struct __pyx_opt_args_13_librootnumpy_array2tree {
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   int __pyx_n;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   std::string name;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   TTree *tree;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 };
 #ifndef CYTHON_REFNANNY
   #define CYTHON_REFNANNY 0
@@ -2227,7 +2227,7 @@ static PyObject *__pyx_f_13_librootnumpy_get_branch_structure(TBranch *); /*prot
 static PyObject *__pyx_f_13_librootnumpy_get_tree_structure(TTree *, struct __pyx_opt_args_13_librootnumpy_get_tree_structure *__pyx_optional_args); /*proto*/
 static PyObject *__pyx_f_13_librootnumpy_humanize_bytes(long, struct __pyx_opt_args_13_librootnumpy_humanize_bytes *__pyx_optional_args); /*proto*/
 static PyObject *__pyx_f_13_librootnumpy_handle_load(int, struct __pyx_opt_args_13_librootnumpy_handle_load *__pyx_optional_args); /*proto*/
-static PyObject *__pyx_f_13_librootnumpy_tree2array(TTree *, PyObject *, std::string, PyObject *, PyObject *, PyObject *, bool, std::string, long); /*proto*/
+static PyObject *__pyx_f_13_librootnumpy_tree2array(TTree *, bool, PyObject *, std::string, PyObject *, PyObject *, PyObject *, bool, std::string, long); /*proto*/
 static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *, struct __pyx_opt_args_13_librootnumpy_array2tree *__pyx_optional_args); /*proto*/
 static CYTHON_INLINE PyArrayObject *__pyx_f_13_librootnumpy_tonumpyarray(void *, int, int); /*proto*/
 static PyObject *__pyx_f_13_librootnumpy__blockwise_inner_join(PyObject *, PyObject *, PyObject *, PyObject *, PyObject *, PyObject *, int __pyx_skip_dispatch); /*proto*/
@@ -2260,11 +2260,12 @@ static PyObject *__pyx_builtin_IndexError;
 static PyObject *__pyx_builtin_enumerate;
 static PyObject *__pyx_builtin_AssertionError;
 static PyObject *__pyx_builtin_xrange;
+static PyObject *__pyx_builtin_RuntimeWarning;
 static PyObject *__pyx_pf_13_librootnumpy_cleanup(CYTHON_UNUSED PyObject *__pyx_self); /* proto */
 static PyObject *__pyx_pf_13_librootnumpy_2list_trees(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_fname); /* proto */
 static PyObject *__pyx_pf_13_librootnumpy_4list_structures(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_fname, PyObject *__pyx_v_tree); /* proto */
 static PyObject *__pyx_pf_13_librootnumpy_6list_branches(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_fname, PyObject *__pyx_v_tree); /* proto */
-static PyObject *__pyx_pf_13_librootnumpy_8root2array_fromfile(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_fnames, std::string __pyx_v_treename, PyObject *__pyx_v_branches, PyObject *__pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size); /* proto */
+static PyObject *__pyx_pf_13_librootnumpy_8root2array_fromfile(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_fnames, std::string __pyx_v_treename, PyObject *__pyx_v_branches, PyObject *__pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size, bool __pyx_v_warn_missing_tree); /* proto */
 static PyObject *__pyx_pf_13_librootnumpy_10root2array_fromtree(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_tree, PyObject *__pyx_v_branches, PyObject *__pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size); /* proto */
 static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_arr, PyObject *__pyx_v_name, PyObject *__pyx_v_tree); /* proto */
 static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_arr, PyObject *__pyx_v_filename, PyObject *__pyx_v_treename, PyObject *__pyx_v_mode); /* proto */
@@ -2389,6 +2390,7 @@ static char __pyx_k_data[] = "data";
 static char __pyx_k_f1_2[] = "f1_";
 static char __pyx_k_f2_2[] = "f2_";
 static char __pyx_k_f3_2[] = "f3_";
+static char __pyx_k_file[] = "file";
 static char __pyx_k_fk_d[] = "fk%d";
 static char __pyx_k_func[] = "func";
 static char __pyx_k_h1_2[] = "h1_";
@@ -2444,7 +2446,6 @@ static char __pyx_k_short[] = "short";
 static char __pyx_k_split[] = "split";
 static char __pyx_k_start[] = "start";
 static char __pyx_k_strip[] = "strip";
-static char __pyx_k_ttree[] = "ttree";
 static char __pyx_k_uint8[] = "uint8";
 static char __pyx_k_utf_8[] = "utf-8";
 static char __pyx_k_1_byte[] = "1 byte";
@@ -2584,6 +2585,7 @@ static char __pyx_k_unsigned_long[] = "unsigned long";
 static char __pyx_k_vector_double[] = "vector<double>";
 static char __pyx_k_vector_string[] = "vector<string>";
 static char __pyx_k_AssertionError[] = "AssertionError";
+static char __pyx_k_RuntimeWarning[] = "RuntimeWarning";
 static char __pyx_k_chain_is_empty[] = "chain is empty";
 static char __pyx_k_evaluate_graph[] = "evaluate_graph";
 static char __pyx_k_include_weight[] = "include_weight";
@@ -2596,6 +2598,7 @@ static char __pyx_k_TYPES_NUMPY2ROOT[] = "TYPES_NUMPY2ROOT";
 static char __pyx_k_vector_long_long[] = "vector<long long>";
 static char __pyx_k_array2tree_toCObj[] = "array2tree_toCObj";
 static char __pyx_k_vector_vector_int[] = "vector<vector<int> >";
+static char __pyx_k_warn_missing_tree[] = "warn_missing_tree";
 static char __pyx_k_cannot_open_file_0[] = "cannot open file {0}";
 static char __pyx_k_extern_ordereddict[] = "extern.ordereddict";
 static char __pyx_k_unsigned_long_long[] = "unsigned long long";
@@ -2642,6 +2645,7 @@ static char __pyx_k_cannot_convert_leaf_0_of_branch[] = "cannot convert leaf '{0
 static char __pyx_k_could_not_find_double_converter[] = "could not find double converter for formula";
 static char __pyx_k_failed_to_allocate_memory_for_0[] = "failed to allocate memory for {0} array of {1} records with {2} fields";
 static char __pyx_k_leaf_list_for_branch_0_is_empty[] = "leaf list for branch '{0}' is empty";
+static char __pyx_k_none_of_the_input_files_contain[] = "none of the input files contain the requested tree '{0}'";
 static char __pyx_k_unknown_dtype_code_in_numpy_pxd[] = "unknown dtype code in numpy.pxd (%d)";
 static char __pyx_k_Format_string_allocated_too_shor[] = "Format string allocated too short, see comment in numpy.pxd";
 static char __pyx_k_Non_native_byte_order_not_suppor[] = "Non-native byte order not supported";
@@ -2689,6 +2693,7 @@ static PyObject *__pyx_n_s_OrderedDict;
 static PyObject *__pyx_n_s_PB;
 static PyObject *__pyx_n_s_RootNumpyUnconvertibleWarning;
 static PyObject *__pyx_n_s_RuntimeError;
+static PyObject *__pyx_n_s_RuntimeWarning;
 static PyObject *__pyx_n_s_S;
 static PyObject *__pyx_n_s_SPECIAL_TYPEDEFS;
 static PyObject *__pyx_kp_s_S_0_d;
@@ -2782,6 +2787,7 @@ static PyObject *__pyx_kp_s_f_s;
 static PyObject *__pyx_kp_s_failed_to_allocate_memory_for_0;
 static PyObject *__pyx_kp_s_field_0_of_type_1_is_not_compati;
 static PyObject *__pyx_n_s_fields;
+static PyObject *__pyx_n_s_file;
 static PyObject *__pyx_kp_s_file_0_is_not_writable;
 static PyObject *__pyx_n_s_filename;
 static PyObject *__pyx_n_s_fill_g1;
@@ -2886,6 +2892,7 @@ static PyObject *__pyx_n_s_names;
 static PyObject *__pyx_kp_u_ndarray_is_not_C_contiguous;
 static PyObject *__pyx_kp_u_ndarray_is_not_Fortran_contiguou;
 static PyObject *__pyx_n_s_nkeys;
+static PyObject *__pyx_kp_s_none_of_the_input_files_contain;
 static PyObject *__pyx_n_s_np;
 static PyObject *__pyx_n_s_numpy;
 static PyObject *__pyx_n_s_object;
@@ -2938,7 +2945,6 @@ static PyObject *__pyx_kp_s_tree_0_not_found_in_1;
 static PyObject *__pyx_kp_s_tree_has_no_branches;
 static PyObject *__pyx_kp_s_tree_index_in_chain_is_out_of_bo;
 static PyObject *__pyx_n_s_treename;
-static PyObject *__pyx_n_s_ttree;
 static PyObject *__pyx_n_s_uint16;
 static PyObject *__pyx_n_s_uint32;
 static PyObject *__pyx_n_s_uint64;
@@ -2985,6 +2991,7 @@ static PyObject *__pyx_kp_b_vector_vector_unsigned_long;
 static PyObject *__pyx_kp_b_vector_vector_unsigned_long_long;
 static PyObject *__pyx_kp_b_vector_vector_unsigned_short;
 static PyObject *__pyx_n_s_warn;
+static PyObject *__pyx_n_s_warn_missing_tree;
 static PyObject *__pyx_n_s_warnings;
 static PyObject *__pyx_n_s_warnings_2;
 static PyObject *__pyx_n_s_weight_name;
@@ -15503,7 +15510,7 @@ static PyObject *__pyx_f_13_librootnumpy_handle_load(int __pyx_v_load, struct __
 /* "root_numpy/src/tree.pyx":118
  * 
  * 
- * cdef object tree2array(TTree* tree, branches, string selection,             # <<<<<<<<<<<<<<
+ * cdef object tree2array(TTree* tree, bool ischain, branches, string selection,             # <<<<<<<<<<<<<<
  *                        start, stop, step,
  *                        bool include_weight, string weight_name,
  */
@@ -15512,7 +15519,7 @@ static PyObject *__pyx_f_13_librootnumpy_handle_load(int __pyx_v_load, struct __
 
 
 #line 118 "root_numpy/src/tree.pyx"
-static PyObject *__pyx_f_13_librootnumpy_tree2array(TTree *__pyx_v_tree, PyObject *__pyx_v_branches, std::string __pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size) {
+static PyObject *__pyx_f_13_librootnumpy_tree2array(TTree *__pyx_v_tree, bool __pyx_v_ischain, PyObject *__pyx_v_branches, std::string __pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size) {
   int __pyx_v_num_requested_branches
 #line 118 "root_numpy/src/tree.pyx"
 ;
@@ -15849,17 +15856,17 @@ static PyObject *__pyx_f_13_librootnumpy_tree2array(TTree *__pyx_v_tree, PyObjec
   /* "root_numpy/src/tree.pyx":136
  *     cdef long long ientry
  * 
- *     cdef TreeChain* chain = new TreeChain(tree, cache_size)             # <<<<<<<<<<<<<<
+ *     cdef TreeChain* chain = new TreeChain(tree, ischain, cache_size)             # <<<<<<<<<<<<<<
  *     handle_load(chain.Prepare(), True)
  * 
  */
 
 #line 136 "root_numpy/src/tree.pyx"
-  __pyx_v_chain = new TreeChain(__pyx_v_tree, __pyx_v_cache_size);
+  __pyx_v_chain = new TreeChain(__pyx_v_tree, __pyx_v_ischain, __pyx_v_cache_size);
 
   /* "root_numpy/src/tree.pyx":137
  * 
- *     cdef TreeChain* chain = new TreeChain(tree, cache_size)
+ *     cdef TreeChain* chain = new TreeChain(tree, ischain, cache_size)
  *     handle_load(chain.Prepare(), True)             # <<<<<<<<<<<<<<
  * 
  *     cdef TObjArray* branch_array = tree.GetListOfBranches()
@@ -19942,7 +19949,7 @@ __pyx_t_9 = PyObject_GetIter(__pyx_v_indices); if (unlikely(!__pyx_t_9)) {__pyx_
   /* "root_numpy/src/tree.pyx":118
  * 
  * 
- * cdef object tree2array(TTree* tree, branches, string selection,             # <<<<<<<<<<<<<<
+ * cdef object tree2array(TTree* tree, bool ischain, branches, string selection,             # <<<<<<<<<<<<<<
  *                        start, stop, step,
  *                        bool include_weight, string weight_name,
  */
@@ -20083,6 +20090,9 @@ static PyObject *__pyx_pw_13_librootnumpy_9root2array_fromfile(PyObject *__pyx_s
   long __pyx_v_cache_size
 #line 370 "root_numpy/src/tree.pyx"
 ;
+  bool __pyx_v_warn_missing_tree
+#line 370 "root_numpy/src/tree.pyx"
+;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -20100,10 +20110,10 @@ static PyObject *__pyx_pw_13_librootnumpy_9root2array_fromfile(PyObject *__pyx_s
   {
 
 #line 370 "root_numpy/src/tree.pyx"
-    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_fnames,&__pyx_n_s_treename,&__pyx_n_s_branches,&__pyx_n_s_selection,&__pyx_n_s_start,&__pyx_n_s_stop,&__pyx_n_s_step,&__pyx_n_s_include_weight,&__pyx_n_s_weight_name,&__pyx_n_s_cache_size,0};
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_fnames,&__pyx_n_s_treename,&__pyx_n_s_branches,&__pyx_n_s_selection,&__pyx_n_s_start,&__pyx_n_s_stop,&__pyx_n_s_step,&__pyx_n_s_include_weight,&__pyx_n_s_weight_name,&__pyx_n_s_cache_size,&__pyx_n_s_warn_missing_tree,0};
 
 #line 370 "root_numpy/src/tree.pyx"
-    PyObject* values[10] = {0,0,0,0,0,0,0,0,0,0};
+    PyObject* values[11] = {0,0,0,0,0,0,0,0,0,0,0};
 
 #line 370 "root_numpy/src/tree.pyx"
     if (unlikely(__pyx_kwds)) {
@@ -20116,6 +20126,9 @@ static PyObject *__pyx_pw_13_librootnumpy_9root2array_fromfile(PyObject *__pyx_s
 
 #line 370 "root_numpy/src/tree.pyx"
       switch (pos_args) {
+        case 11: 
+#line 370 "root_numpy/src/tree.pyx"
+values[10] = PyTuple_GET_ITEM(__pyx_args, 10);
         case 10: 
 #line 370 "root_numpy/src/tree.pyx"
 values[9] = PyTuple_GET_ITEM(__pyx_args, 9);
@@ -20179,7 +20192,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 1); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 1); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20194,7 +20207,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 2); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 2); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20209,7 +20222,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 3); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 3); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20224,7 +20237,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 4); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 4); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20239,7 +20252,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 5); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 5); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20254,7 +20267,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 6); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 6); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20269,7 +20282,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 7); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 7); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20284,7 +20297,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 8); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 8); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20299,7 +20312,22 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
         else {
-          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, 9); 
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 9); 
+#line 370 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+
+#line 370 "root_numpy/src/tree.pyx"
+        }
+
+#line 370 "root_numpy/src/tree.pyx"
+        case 10:
+
+#line 370 "root_numpy/src/tree.pyx"
+        if (likely((values[10] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_warn_missing_tree)) != 0)) kw_args--;
+
+#line 370 "root_numpy/src/tree.pyx"
+        else {
+          __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, 10); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20319,7 +20347,7 @@ goto __pyx_L5_argtuple_error;
       }
 
 #line 370 "root_numpy/src/tree.pyx"
-    } else if (PyTuple_GET_SIZE(__pyx_args) != 10) {
+    } else if (PyTuple_GET_SIZE(__pyx_args) != 11) {
 
 #line 370 "root_numpy/src/tree.pyx"
       goto __pyx_L5_argtuple_error;
@@ -20358,6 +20386,9 @@ goto __pyx_L5_argtuple_error;
       values[9] = PyTuple_GET_ITEM(__pyx_args, 9);
 
 #line 370 "root_numpy/src/tree.pyx"
+      values[10] = PyTuple_GET_ITEM(__pyx_args, 10);
+
+#line 370 "root_numpy/src/tree.pyx"
     }
 
 #line 370 "root_numpy/src/tree.pyx"
@@ -20391,6 +20422,9 @@ goto __pyx_L5_argtuple_error;
     __pyx_v_cache_size = __Pyx_PyInt_As_long(values[9]); if (unlikely((__pyx_v_cache_size == (long)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 373; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
 #line 370 "root_numpy/src/tree.pyx"
+    __pyx_v_warn_missing_tree = __Pyx_PyObject_IsTrue(values[10]); if (unlikely((__pyx_v_warn_missing_tree == (bool)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 373; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+
+#line 370 "root_numpy/src/tree.pyx"
   }
 
 #line 370 "root_numpy/src/tree.pyx"
@@ -20398,7 +20432,7 @@ goto __pyx_L5_argtuple_error;
 
 #line 370 "root_numpy/src/tree.pyx"
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 10, 10, PyTuple_GET_SIZE(__pyx_args)); 
+  __Pyx_RaiseArgtupleInvalid("root2array_fromfile", 1, 11, 11, PyTuple_GET_SIZE(__pyx_args)); 
 #line 370 "root_numpy/src/tree.pyx"
 {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
@@ -20418,7 +20452,7 @@ goto __pyx_L5_argtuple_error;
   __pyx_L4_argument_unpacking_done:;
   __pyx_r = 
 #line 370 "root_numpy/src/tree.pyx"
-__pyx_pf_13_librootnumpy_8root2array_fromfile(__pyx_self, __pyx_v_fnames, __pyx_v_treename, __pyx_v_branches, __pyx_v_selection, __pyx_v_start, __pyx_v_stop, __pyx_v_step, __pyx_v_include_weight, __pyx_v_weight_name, __pyx_v_cache_size);
+__pyx_pf_13_librootnumpy_8root2array_fromfile(__pyx_self, __pyx_v_fnames, __pyx_v_treename, __pyx_v_branches, __pyx_v_selection, __pyx_v_start, __pyx_v_stop, __pyx_v_step, __pyx_v_include_weight, __pyx_v_weight_name, __pyx_v_cache_size, __pyx_v_warn_missing_tree);
 
 #line 370 "root_numpy/src/tree.pyx"
 
@@ -20439,8 +20473,14 @@ __pyx_pf_13_librootnumpy_8root2array_fromfile(__pyx_self, __pyx_v_fnames, __pyx_
 
 
 #line 370 "root_numpy/src/tree.pyx"
-static PyObject *__pyx_pf_13_librootnumpy_8root2array_fromfile(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_fnames, std::string __pyx_v_treename, PyObject *__pyx_v_branches, PyObject *__pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size) {
-  TChain *__pyx_v_ttree
+static PyObject *__pyx_pf_13_librootnumpy_8root2array_fromfile(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_fnames, std::string __pyx_v_treename, PyObject *__pyx_v_branches, PyObject *__pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size, bool __pyx_v_warn_missing_tree) {
+  TChain *__pyx_v_chain
+#line 370 "root_numpy/src/tree.pyx"
+;
+  TFile *__pyx_v_file
+#line 370 "root_numpy/src/tree.pyx"
+;
+  TTree *__pyx_v_tree
 #line 370 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_fn = NULL
@@ -20457,24 +20497,26 @@ static PyObject *__pyx_pf_13_librootnumpy_8root2array_fromfile(CYTHON_UNUSED PyO
   Py_ssize_t __pyx_t_2;
   PyObject *(*__pyx_t_3)(PyObject *);
   PyObject *__pyx_t_4 = NULL;
-  const char *__pyx_t_5;
-  int __pyx_t_6;
+  int __pyx_t_5;
+  const char *__pyx_t_6;
   PyObject *__pyx_t_7 = NULL;
   PyObject *__pyx_t_8 = NULL;
   PyObject *__pyx_t_9 = NULL;
-  Py_ssize_t __pyx_t_10;
+  PyObject *__pyx_t_10 = NULL;
   PyObject *__pyx_t_11 = NULL;
-  std::string __pyx_t_12;
-  std::string __pyx_t_13;
-  int __pyx_t_14;
-  int __pyx_t_15;
-  char const *__pyx_t_16;
-  PyObject *__pyx_t_17 = NULL;
-  PyObject *__pyx_t_18 = NULL;
+  Py_ssize_t __pyx_t_12;
+  PyObject *__pyx_t_13 = NULL;
+  std::string __pyx_t_14;
+  std::string __pyx_t_15;
+  int __pyx_t_16;
+  int __pyx_t_17;
+  char const *__pyx_t_18;
   PyObject *__pyx_t_19 = NULL;
   PyObject *__pyx_t_20 = NULL;
   PyObject *__pyx_t_21 = NULL;
   PyObject *__pyx_t_22 = NULL;
+  PyObject *__pyx_t_23 = NULL;
+  PyObject *__pyx_t_24 = NULL;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -20484,559 +20526,1202 @@ static PyObject *__pyx_pf_13_librootnumpy_8root2array_fromfile(CYTHON_UNUSED PyO
 
   /* "root_numpy/src/tree.pyx":374
  *                         bool include_weight, string weight_name,
- *                         long cache_size):
- *     cdef TChain* ttree = NULL             # <<<<<<<<<<<<<<
- *     try:
- *         ttree = new TChain(treename.c_str())
+ *                         long cache_size, bool warn_missing_tree):
+ *     cdef TChain* chain = NULL             # <<<<<<<<<<<<<<
+ *     cdef TFile* file = NULL
+ *     cdef TTree* tree = NULL
  */
 
 #line 374 "root_numpy/src/tree.pyx"
-  __pyx_v_ttree = NULL;
+  __pyx_v_chain = NULL;
 
   /* "root_numpy/src/tree.pyx":375
- *                         long cache_size):
- *     cdef TChain* ttree = NULL
- *     try:             # <<<<<<<<<<<<<<
- *         ttree = new TChain(treename.c_str())
- *         for fn in fnames:
+ *                         long cache_size, bool warn_missing_tree):
+ *     cdef TChain* chain = NULL
+ *     cdef TFile* file = NULL             # <<<<<<<<<<<<<<
+ *     cdef TTree* tree = NULL
+ *     try:
  */
 
 #line 375 "root_numpy/src/tree.pyx"
-  /*try:*/ {
+  __pyx_v_file = NULL;
 
-    /* "root_numpy/src/tree.pyx":376
- *     cdef TChain* ttree = NULL
+  /* "root_numpy/src/tree.pyx":376
+ *     cdef TChain* chain = NULL
+ *     cdef TFile* file = NULL
+ *     cdef TTree* tree = NULL             # <<<<<<<<<<<<<<
  *     try:
- *         ttree = new TChain(treename.c_str())             # <<<<<<<<<<<<<<
- *         for fn in fnames:
- *             if ttree.Add(fn, -1) == 0:
+ *         chain = new TChain(treename.c_str())
  */
 
 #line 376 "root_numpy/src/tree.pyx"
-    __pyx_v_ttree = new TChain(__pyx_v_treename.c_str());
+  __pyx_v_tree = NULL;
 
-    /* "root_numpy/src/tree.pyx":377
- *     try:
- *         ttree = new TChain(treename.c_str())
- *         for fn in fnames:             # <<<<<<<<<<<<<<
- *             if ttree.Add(fn, -1) == 0:
- *                 raise IOError("unable to access tree '{0}' in {1}".format(
+  /* "root_numpy/src/tree.pyx":377
+ *     cdef TFile* file = NULL
+ *     cdef TTree* tree = NULL
+ *     try:             # <<<<<<<<<<<<<<
+ *         chain = new TChain(treename.c_str())
+ *         for fn in fnames:
  */
 
 #line 377 "root_numpy/src/tree.pyx"
+  /*try:*/ {
+
+    /* "root_numpy/src/tree.pyx":378
+ *     cdef TTree* tree = NULL
+ *     try:
+ *         chain = new TChain(treename.c_str())             # <<<<<<<<<<<<<<
+ *         for fn in fnames:
+ *             if warn_missing_tree:
+ */
+
+#line 378 "root_numpy/src/tree.pyx"
+    __pyx_v_chain = new TChain(__pyx_v_treename.c_str());
+
+    /* "root_numpy/src/tree.pyx":379
+ *     try:
+ *         chain = new TChain(treename.c_str())
+ *         for fn in fnames:             # <<<<<<<<<<<<<<
+ *             if warn_missing_tree:
+ *                 file = Open(fn, 'read')
+ */
+
+#line 379 "root_numpy/src/tree.pyx"
     if (likely(PyList_CheckExact(__pyx_v_fnames)) || PyTuple_CheckExact(__pyx_v_fnames)) {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
       __pyx_t_1 = __pyx_v_fnames; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
       __pyx_t_3 = NULL;
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
     } else {
       __pyx_t_2 = -1; 
-#line 377 "root_numpy/src/tree.pyx"
-__pyx_t_1 = PyObject_GetIter(__pyx_v_fnames); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 377; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 379 "root_numpy/src/tree.pyx"
+__pyx_t_1 = PyObject_GetIter(__pyx_v_fnames); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
       __Pyx_GOTREF(__pyx_t_1);
 
-#line 377 "root_numpy/src/tree.pyx"
-      __pyx_t_3 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 377; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 379 "root_numpy/src/tree.pyx"
+      __pyx_t_3 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
     }
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
     for (;;) {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
       if (likely(!__pyx_t_3)) {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
         if (likely(PyList_CheckExact(__pyx_t_1))) {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           #if CYTHON_COMPILING_IN_CPYTHON
 
-#line 377 "root_numpy/src/tree.pyx"
-          __pyx_t_4 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 377; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 379 "root_numpy/src/tree.pyx"
+          __pyx_t_4 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           #else
 
-#line 377 "root_numpy/src/tree.pyx"
-          __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 377; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 379 "root_numpy/src/tree.pyx"
+          __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           #endif
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
         } else {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           if (__pyx_t_2 >= PyTuple_GET_SIZE(__pyx_t_1)) break;
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           #if CYTHON_COMPILING_IN_CPYTHON
 
-#line 377 "root_numpy/src/tree.pyx"
-          __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 377; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 379 "root_numpy/src/tree.pyx"
+          __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           #else
 
-#line 377 "root_numpy/src/tree.pyx"
-          __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 377; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 379 "root_numpy/src/tree.pyx"
+          __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           #endif
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
         }
       } else 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
 {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
         __pyx_t_4 = __pyx_t_3(__pyx_t_1);
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
         if (unlikely(!__pyx_t_4)) {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           PyObject* exc_type = PyErr_Occurred();
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           if (exc_type) {
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
             if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
 
-#line 377 "root_numpy/src/tree.pyx"
-            else {__pyx_filename = __pyx_f[2]; __pyx_lineno = 377; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 379 "root_numpy/src/tree.pyx"
+            else {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           }
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
           break;
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
         }
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_4);
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
       }
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF_SET(__pyx_v_fn, __pyx_t_4);
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
       __pyx_t_4 = 0;
 
-      /* "root_numpy/src/tree.pyx":378
- *         ttree = new TChain(treename.c_str())
+      /* "root_numpy/src/tree.pyx":380
+ *         chain = new TChain(treename.c_str())
  *         for fn in fnames:
- *             if ttree.Add(fn, -1) == 0:             # <<<<<<<<<<<<<<
- *                 raise IOError("unable to access tree '{0}' in {1}".format(
- *                     treename, fn))
+ *             if warn_missing_tree:             # <<<<<<<<<<<<<<
+ *                 file = Open(fn, 'read')
+ *                 if file == NULL:
  */
 
-#line 378 "root_numpy/src/tree.pyx"
-      __pyx_t_5 = __Pyx_PyObject_AsString(__pyx_v_fn); if (unlikely((!__pyx_t_5) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 378; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 380 "root_numpy/src/tree.pyx"
+      __pyx_t_5 = (__pyx_v_warn_missing_tree != 0);
 
-#line 378 "root_numpy/src/tree.pyx"
-      __pyx_t_6 = ((__pyx_v_ttree->Add(__pyx_t_5, -1) == 0) != 0);
+#line 380 "root_numpy/src/tree.pyx"
+      if (__pyx_t_5) {
 
-#line 378 "root_numpy/src/tree.pyx"
-      if (__pyx_t_6) {
-
-        /* "root_numpy/src/tree.pyx":379
+        /* "root_numpy/src/tree.pyx":381
  *         for fn in fnames:
- *             if ttree.Add(fn, -1) == 0:
- *                 raise IOError("unable to access tree '{0}' in {1}".format(             # <<<<<<<<<<<<<<
- *                     treename, fn))
- *         ret = tree2array(
+ *             if warn_missing_tree:
+ *                 file = Open(fn, 'read')             # <<<<<<<<<<<<<<
+ *                 if file == NULL:
+ *                     raise IOError("cannot open file {0}".format(fn))
  */
 
-#line 379 "root_numpy/src/tree.pyx"
-        __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_unable_to_access_tree_0_in_1, __pyx_n_s_format); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 381 "root_numpy/src/tree.pyx"
+        __pyx_t_6 = __Pyx_PyObject_AsString(__pyx_v_fn); if (unlikely((!__pyx_t_6) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 381; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 379 "root_numpy/src/tree.pyx"
-        __Pyx_GOTREF(__pyx_t_7);
+#line 381 "root_numpy/src/tree.pyx"
+        __pyx_v_file = TFile::Open(__pyx_t_6, __pyx_k_read);
 
-        /* "root_numpy/src/tree.pyx":380
- *             if ttree.Add(fn, -1) == 0:
- *                 raise IOError("unable to access tree '{0}' in {1}".format(
- *                     treename, fn))             # <<<<<<<<<<<<<<
- *         ret = tree2array(
- *             <TTree*> ttree, branches,
+        /* "root_numpy/src/tree.pyx":382
+ *             if warn_missing_tree:
+ *                 file = Open(fn, 'read')
+ *                 if file == NULL:             # <<<<<<<<<<<<<<
+ *                     raise IOError("cannot open file {0}".format(fn))
+ *                 tree = <TTree*> file.Get(treename.c_str())
  */
 
-#line 380 "root_numpy/src/tree.pyx"
-        __pyx_t_8 = __pyx_convert_PyStr_string_to_py_std__string(__pyx_v_treename); if (unlikely(!__pyx_t_8)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 380; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 382 "root_numpy/src/tree.pyx"
+        __pyx_t_5 = ((__pyx_v_file == NULL) != 0);
 
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_GOTREF(__pyx_t_8);
+#line 382 "root_numpy/src/tree.pyx"
+        if (__pyx_t_5) {
 
-#line 380 "root_numpy/src/tree.pyx"
-        __pyx_t_9 = NULL;
+          /* "root_numpy/src/tree.pyx":383
+ *                 file = Open(fn, 'read')
+ *                 if file == NULL:
+ *                     raise IOError("cannot open file {0}".format(fn))             # <<<<<<<<<<<<<<
+ *                 tree = <TTree*> file.Get(treename.c_str())
+ *                 if tree == NULL:
+ */
 
-#line 380 "root_numpy/src/tree.pyx"
-        __pyx_t_10 = 0;
+#line 383 "root_numpy/src/tree.pyx"
+          __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_cannot_open_file_0, __pyx_n_s_format); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 380 "root_numpy/src/tree.pyx"
-        if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_7))) {
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_7);
 
-#line 380 "root_numpy/src/tree.pyx"
-          __pyx_t_9 = PyMethod_GET_SELF(__pyx_t_7);
+#line 383 "root_numpy/src/tree.pyx"
+          __pyx_t_8 = NULL;
 
-#line 380 "root_numpy/src/tree.pyx"
-          if (likely(__pyx_t_9)) {
+#line 383 "root_numpy/src/tree.pyx"
+          if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_7))) {
 
-#line 380 "root_numpy/src/tree.pyx"
-            PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_7);
+#line 383 "root_numpy/src/tree.pyx"
+            __pyx_t_8 = PyMethod_GET_SELF(__pyx_t_7);
 
-#line 380 "root_numpy/src/tree.pyx"
-            __Pyx_INCREF(__pyx_t_9);
+#line 383 "root_numpy/src/tree.pyx"
+            if (likely(__pyx_t_8)) {
 
-#line 380 "root_numpy/src/tree.pyx"
-            __Pyx_INCREF(function);
+#line 383 "root_numpy/src/tree.pyx"
+              PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_7);
 
-#line 380 "root_numpy/src/tree.pyx"
-            __Pyx_DECREF_SET(__pyx_t_7, function);
+#line 383 "root_numpy/src/tree.pyx"
+              __Pyx_INCREF(__pyx_t_8);
 
-#line 380 "root_numpy/src/tree.pyx"
-            __pyx_t_10 = 1;
+#line 383 "root_numpy/src/tree.pyx"
+              __Pyx_INCREF(function);
 
-#line 380 "root_numpy/src/tree.pyx"
+#line 383 "root_numpy/src/tree.pyx"
+              __Pyx_DECREF_SET(__pyx_t_7, function);
+
+#line 383 "root_numpy/src/tree.pyx"
+            }
+
+#line 383 "root_numpy/src/tree.pyx"
           }
 
-#line 380 "root_numpy/src/tree.pyx"
+#line 383 "root_numpy/src/tree.pyx"
+          if (!__pyx_t_8) {
+
+#line 383 "root_numpy/src/tree.pyx"
+            __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_7, __pyx_v_fn); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 383 "root_numpy/src/tree.pyx"
+            __Pyx_GOTREF(__pyx_t_4);
+
+#line 383 "root_numpy/src/tree.pyx"
+          } else {
+
+#line 383 "root_numpy/src/tree.pyx"
+            __pyx_t_9 = PyTuple_New(1+1); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 383 "root_numpy/src/tree.pyx"
+            __Pyx_GOTREF(__pyx_t_9);
+
+#line 383 "root_numpy/src/tree.pyx"
+            PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_8); __Pyx_GIVEREF(__pyx_t_8); __pyx_t_8 = NULL;
+
+#line 383 "root_numpy/src/tree.pyx"
+            __Pyx_INCREF(__pyx_v_fn);
+
+#line 383 "root_numpy/src/tree.pyx"
+            PyTuple_SET_ITEM(__pyx_t_9, 0+1, __pyx_v_fn);
+
+#line 383 "root_numpy/src/tree.pyx"
+            __Pyx_GIVEREF(__pyx_v_fn);
+
+#line 383 "root_numpy/src/tree.pyx"
+            __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_7, __pyx_t_9, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 383 "root_numpy/src/tree.pyx"
+            __Pyx_GOTREF(__pyx_t_4);
+
+#line 383 "root_numpy/src/tree.pyx"
+            __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
+
+#line 383 "root_numpy/src/tree.pyx"
+          }
+
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
+
+#line 383 "root_numpy/src/tree.pyx"
+          __pyx_t_7 = PyTuple_New(1); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_7);
+
+#line 383 "root_numpy/src/tree.pyx"
+          PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_4);
+
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_GIVEREF(__pyx_t_4);
+
+#line 383 "root_numpy/src/tree.pyx"
+          __pyx_t_4 = 0;
+
+#line 383 "root_numpy/src/tree.pyx"
+          __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_4);
+
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
+
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_Raise(__pyx_t_4, 0, 0, 0);
+
+#line 383 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+
+#line 383 "root_numpy/src/tree.pyx"
+          {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 383 "root_numpy/src/tree.pyx"
         }
 
-#line 380 "root_numpy/src/tree.pyx"
-        __pyx_t_11 = PyTuple_New(2+__pyx_t_10); if (unlikely(!__pyx_t_11)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
-
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_GOTREF(__pyx_t_11);
-
-#line 380 "root_numpy/src/tree.pyx"
-        if (__pyx_t_9) {
-
-#line 380 "root_numpy/src/tree.pyx"
-          PyTuple_SET_ITEM(__pyx_t_11, 0, __pyx_t_9); __Pyx_GIVEREF(__pyx_t_9); __pyx_t_9 = NULL;
-
-#line 380 "root_numpy/src/tree.pyx"
-        }
-
-#line 380 "root_numpy/src/tree.pyx"
-        PyTuple_SET_ITEM(__pyx_t_11, 0+__pyx_t_10, __pyx_t_8);
-
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_GIVEREF(__pyx_t_8);
-
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_INCREF(__pyx_v_fn);
-
-#line 380 "root_numpy/src/tree.pyx"
-        PyTuple_SET_ITEM(__pyx_t_11, 1+__pyx_t_10, __pyx_v_fn);
-
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_GIVEREF(__pyx_v_fn);
-
-#line 380 "root_numpy/src/tree.pyx"
-        __pyx_t_8 = 0;
-
-#line 380 "root_numpy/src/tree.pyx"
-        __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_7, __pyx_t_11, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
-
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_GOTREF(__pyx_t_4);
-
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-
-#line 380 "root_numpy/src/tree.pyx"
-        __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-
-        /* "root_numpy/src/tree.pyx":379
- *         for fn in fnames:
- *             if ttree.Add(fn, -1) == 0:
- *                 raise IOError("unable to access tree '{0}' in {1}".format(             # <<<<<<<<<<<<<<
- *                     treename, fn))
- *         ret = tree2array(
+        /* "root_numpy/src/tree.pyx":384
+ *                 if file == NULL:
+ *                     raise IOError("cannot open file {0}".format(fn))
+ *                 tree = <TTree*> file.Get(treename.c_str())             # <<<<<<<<<<<<<<
+ *                 if tree == NULL:
+ *                     # skip this file
  */
 
-#line 379 "root_numpy/src/tree.pyx"
-        __pyx_t_7 = PyTuple_New(1); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 384 "root_numpy/src/tree.pyx"
+        __pyx_v_tree = ((TTree *)__pyx_v_file->Get(__pyx_v_treename.c_str()));
 
-#line 379 "root_numpy/src/tree.pyx"
-        __Pyx_GOTREF(__pyx_t_7);
+        /* "root_numpy/src/tree.pyx":385
+ *                     raise IOError("cannot open file {0}".format(fn))
+ *                 tree = <TTree*> file.Get(treename.c_str())
+ *                 if tree == NULL:             # <<<<<<<<<<<<<<
+ *                     # skip this file
+ *                     warnings.warn("tree '{0}' not found in {1}".format(treename, fn),
+ */
 
-#line 379 "root_numpy/src/tree.pyx"
-        PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_4);
+#line 385 "root_numpy/src/tree.pyx"
+        __pyx_t_5 = ((__pyx_v_tree == NULL) != 0);
 
-#line 379 "root_numpy/src/tree.pyx"
-        __Pyx_GIVEREF(__pyx_t_4);
+#line 385 "root_numpy/src/tree.pyx"
+        if (__pyx_t_5) {
 
-#line 379 "root_numpy/src/tree.pyx"
-        __pyx_t_4 = 0;
+          /* "root_numpy/src/tree.pyx":387
+ *                 if tree == NULL:
+ *                     # skip this file
+ *                     warnings.warn("tree '{0}' not found in {1}".format(treename, fn),             # <<<<<<<<<<<<<<
+ *                                   RuntimeWarning)
+ *                     file.Close()
+ */
 
-#line 379 "root_numpy/src/tree.pyx"
-        __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_7 = __Pyx_GetModuleGlobalName(__pyx_n_s_warnings); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 379 "root_numpy/src/tree.pyx"
-        __Pyx_GOTREF(__pyx_t_4);
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_7);
 
-#line 379 "root_numpy/src/tree.pyx"
-        __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_t_7, __pyx_n_s_warn); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 379 "root_numpy/src/tree.pyx"
-        __Pyx_Raise(__pyx_t_4, 0, 0, 0);
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_9);
 
-#line 379 "root_numpy/src/tree.pyx"
-        __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-#line 379 "root_numpy/src/tree.pyx"
-        {__pyx_filename = __pyx_f[2]; __pyx_lineno = 379; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_8 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_tree_0_not_found_in_1, __pyx_n_s_format); if (unlikely(!__pyx_t_8)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 379 "root_numpy/src/tree.pyx"
-      }
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_8);
 
-      /* "root_numpy/src/tree.pyx":377
- *     try:
- *         ttree = new TChain(treename.c_str())
- *         for fn in fnames:             # <<<<<<<<<<<<<<
- *             if ttree.Add(fn, -1) == 0:
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_10 = __pyx_convert_PyStr_string_to_py_std__string(__pyx_v_treename); if (unlikely(!__pyx_t_10)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_10);
+
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_11 = NULL;
+
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_12 = 0;
+
+#line 387 "root_numpy/src/tree.pyx"
+          if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_8))) {
+
+#line 387 "root_numpy/src/tree.pyx"
+            __pyx_t_11 = PyMethod_GET_SELF(__pyx_t_8);
+
+#line 387 "root_numpy/src/tree.pyx"
+            if (likely(__pyx_t_11)) {
+
+#line 387 "root_numpy/src/tree.pyx"
+              PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_8);
+
+#line 387 "root_numpy/src/tree.pyx"
+              __Pyx_INCREF(__pyx_t_11);
+
+#line 387 "root_numpy/src/tree.pyx"
+              __Pyx_INCREF(function);
+
+#line 387 "root_numpy/src/tree.pyx"
+              __Pyx_DECREF_SET(__pyx_t_8, function);
+
+#line 387 "root_numpy/src/tree.pyx"
+              __pyx_t_12 = 1;
+
+#line 387 "root_numpy/src/tree.pyx"
+            }
+
+#line 387 "root_numpy/src/tree.pyx"
+          }
+
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_13 = PyTuple_New(2+__pyx_t_12); if (unlikely(!__pyx_t_13)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_13);
+
+#line 387 "root_numpy/src/tree.pyx"
+          if (__pyx_t_11) {
+
+#line 387 "root_numpy/src/tree.pyx"
+            PyTuple_SET_ITEM(__pyx_t_13, 0, __pyx_t_11); __Pyx_GIVEREF(__pyx_t_11); __pyx_t_11 = NULL;
+
+#line 387 "root_numpy/src/tree.pyx"
+          }
+
+#line 387 "root_numpy/src/tree.pyx"
+          PyTuple_SET_ITEM(__pyx_t_13, 0+__pyx_t_12, __pyx_t_10);
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GIVEREF(__pyx_t_10);
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_INCREF(__pyx_v_fn);
+
+#line 387 "root_numpy/src/tree.pyx"
+          PyTuple_SET_ITEM(__pyx_t_13, 1+__pyx_t_12, __pyx_v_fn);
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GIVEREF(__pyx_v_fn);
+
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_10 = 0;
+
+#line 387 "root_numpy/src/tree.pyx"
+          __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_8, __pyx_t_13, NULL); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_7);
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
+
+#line 387 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
+
+          /* "root_numpy/src/tree.pyx":388
+ *                     # skip this file
+ *                     warnings.warn("tree '{0}' not found in {1}".format(treename, fn),
+ *                                   RuntimeWarning)             # <<<<<<<<<<<<<<
+ *                     file.Close()
+ *                     continue
+ */
+
+#line 388 "root_numpy/src/tree.pyx"
+          __pyx_t_8 = NULL;
+
+#line 388 "root_numpy/src/tree.pyx"
+          __pyx_t_12 = 0;
+
+#line 388 "root_numpy/src/tree.pyx"
+          if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_9))) {
+
+#line 388 "root_numpy/src/tree.pyx"
+            __pyx_t_8 = PyMethod_GET_SELF(__pyx_t_9);
+
+#line 388 "root_numpy/src/tree.pyx"
+            if (likely(__pyx_t_8)) {
+
+#line 388 "root_numpy/src/tree.pyx"
+              PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_9);
+
+#line 388 "root_numpy/src/tree.pyx"
+              __Pyx_INCREF(__pyx_t_8);
+
+#line 388 "root_numpy/src/tree.pyx"
+              __Pyx_INCREF(function);
+
+#line 388 "root_numpy/src/tree.pyx"
+              __Pyx_DECREF_SET(__pyx_t_9, function);
+
+#line 388 "root_numpy/src/tree.pyx"
+              __pyx_t_12 = 1;
+
+#line 388 "root_numpy/src/tree.pyx"
+            }
+
+#line 388 "root_numpy/src/tree.pyx"
+          }
+
+#line 388 "root_numpy/src/tree.pyx"
+          __pyx_t_13 = PyTuple_New(2+__pyx_t_12); if (unlikely(!__pyx_t_13)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_13);
+
+#line 388 "root_numpy/src/tree.pyx"
+          if (__pyx_t_8) {
+
+#line 388 "root_numpy/src/tree.pyx"
+            PyTuple_SET_ITEM(__pyx_t_13, 0, __pyx_t_8); __Pyx_GIVEREF(__pyx_t_8); __pyx_t_8 = NULL;
+
+#line 388 "root_numpy/src/tree.pyx"
+          }
+
+#line 388 "root_numpy/src/tree.pyx"
+          PyTuple_SET_ITEM(__pyx_t_13, 0+__pyx_t_12, __pyx_t_7);
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_GIVEREF(__pyx_t_7);
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_INCREF(__pyx_builtin_RuntimeWarning);
+
+#line 388 "root_numpy/src/tree.pyx"
+          PyTuple_SET_ITEM(__pyx_t_13, 1+__pyx_t_12, __pyx_builtin_RuntimeWarning);
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_GIVEREF(__pyx_builtin_RuntimeWarning);
+
+#line 388 "root_numpy/src/tree.pyx"
+          __pyx_t_7 = 0;
+
+#line 388 "root_numpy/src/tree.pyx"
+          __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_9, __pyx_t_13, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 387; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_GOTREF(__pyx_t_4);
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
+
+#line 388 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+
+          /* "root_numpy/src/tree.pyx":389
+ *                     warnings.warn("tree '{0}' not found in {1}".format(treename, fn),
+ *                                   RuntimeWarning)
+ *                     file.Close()             # <<<<<<<<<<<<<<
+ *                     continue
+ *                 del tree
+ */
+
+#line 389 "root_numpy/src/tree.pyx"
+          __pyx_v_file->Close();
+
+          /* "root_numpy/src/tree.pyx":390
+ *                                   RuntimeWarning)
+ *                     file.Close()
+ *                     continue             # <<<<<<<<<<<<<<
+ *                 del tree
+ *                 file.Close()
+ */
+
+#line 390 "root_numpy/src/tree.pyx"
+          goto __pyx_L6_continue;
+
+#line 390 "root_numpy/src/tree.pyx"
+        }
+
+        /* "root_numpy/src/tree.pyx":391
+ *                     file.Close()
+ *                     continue
+ *                 del tree             # <<<<<<<<<<<<<<
+ *                 file.Close()
+ *             if chain.Add(fn, -1) == 0:
+ */
+
+#line 391 "root_numpy/src/tree.pyx"
+        delete __pyx_v_tree;
+
+        /* "root_numpy/src/tree.pyx":392
+ *                     continue
+ *                 del tree
+ *                 file.Close()             # <<<<<<<<<<<<<<
+ *             if chain.Add(fn, -1) == 0:
  *                 raise IOError("unable to access tree '{0}' in {1}".format(
  */
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 392 "root_numpy/src/tree.pyx"
+        __pyx_v_file->Close();
+
+#line 392 "root_numpy/src/tree.pyx"
+        goto __pyx_L8;
+
+#line 392 "root_numpy/src/tree.pyx"
+      }
+
+#line 392 "root_numpy/src/tree.pyx"
+      __pyx_L8:;
+
+      /* "root_numpy/src/tree.pyx":393
+ *                 del tree
+ *                 file.Close()
+ *             if chain.Add(fn, -1) == 0:             # <<<<<<<<<<<<<<
+ *                 raise IOError("unable to access tree '{0}' in {1}".format(
+ *                     treename, fn))
+ */
+
+#line 393 "root_numpy/src/tree.pyx"
+      __pyx_t_6 = __Pyx_PyObject_AsString(__pyx_v_fn); if (unlikely((!__pyx_t_6) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 393; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 393 "root_numpy/src/tree.pyx"
+      __pyx_t_5 = ((__pyx_v_chain->Add(__pyx_t_6, -1) == 0) != 0);
+
+#line 393 "root_numpy/src/tree.pyx"
+      if (__pyx_t_5) {
+
+        /* "root_numpy/src/tree.pyx":394
+ *                 file.Close()
+ *             if chain.Add(fn, -1) == 0:
+ *                 raise IOError("unable to access tree '{0}' in {1}".format(             # <<<<<<<<<<<<<<
+ *                     treename, fn))
+ *         if chain.GetNtrees() == 0:
+ */
+
+#line 394 "root_numpy/src/tree.pyx"
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_unable_to_access_tree_0_in_1, __pyx_n_s_format); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 394; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 394 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_9);
+
+        /* "root_numpy/src/tree.pyx":395
+ *             if chain.Add(fn, -1) == 0:
+ *                 raise IOError("unable to access tree '{0}' in {1}".format(
+ *                     treename, fn))             # <<<<<<<<<<<<<<
+ *         if chain.GetNtrees() == 0:
+ *             raise IOError("none of the input files contain "
+ */
+
+#line 395 "root_numpy/src/tree.pyx"
+        __pyx_t_13 = __pyx_convert_PyStr_string_to_py_std__string(__pyx_v_treename); if (unlikely(!__pyx_t_13)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 395; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_13);
+
+#line 395 "root_numpy/src/tree.pyx"
+        __pyx_t_7 = NULL;
+
+#line 395 "root_numpy/src/tree.pyx"
+        __pyx_t_12 = 0;
+
+#line 395 "root_numpy/src/tree.pyx"
+        if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_9))) {
+
+#line 395 "root_numpy/src/tree.pyx"
+          __pyx_t_7 = PyMethod_GET_SELF(__pyx_t_9);
+
+#line 395 "root_numpy/src/tree.pyx"
+          if (likely(__pyx_t_7)) {
+
+#line 395 "root_numpy/src/tree.pyx"
+            PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_9);
+
+#line 395 "root_numpy/src/tree.pyx"
+            __Pyx_INCREF(__pyx_t_7);
+
+#line 395 "root_numpy/src/tree.pyx"
+            __Pyx_INCREF(function);
+
+#line 395 "root_numpy/src/tree.pyx"
+            __Pyx_DECREF_SET(__pyx_t_9, function);
+
+#line 395 "root_numpy/src/tree.pyx"
+            __pyx_t_12 = 1;
+
+#line 395 "root_numpy/src/tree.pyx"
+          }
+
+#line 395 "root_numpy/src/tree.pyx"
+        }
+
+#line 395 "root_numpy/src/tree.pyx"
+        __pyx_t_8 = PyTuple_New(2+__pyx_t_12); if (unlikely(!__pyx_t_8)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 394; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_8);
+
+#line 395 "root_numpy/src/tree.pyx"
+        if (__pyx_t_7) {
+
+#line 395 "root_numpy/src/tree.pyx"
+          PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_7); __Pyx_GIVEREF(__pyx_t_7); __pyx_t_7 = NULL;
+
+#line 395 "root_numpy/src/tree.pyx"
+        }
+
+#line 395 "root_numpy/src/tree.pyx"
+        PyTuple_SET_ITEM(__pyx_t_8, 0+__pyx_t_12, __pyx_t_13);
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_GIVEREF(__pyx_t_13);
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_INCREF(__pyx_v_fn);
+
+#line 395 "root_numpy/src/tree.pyx"
+        PyTuple_SET_ITEM(__pyx_t_8, 1+__pyx_t_12, __pyx_v_fn);
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_GIVEREF(__pyx_v_fn);
+
+#line 395 "root_numpy/src/tree.pyx"
+        __pyx_t_13 = 0;
+
+#line 395 "root_numpy/src/tree.pyx"
+        __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_9, __pyx_t_8, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 394; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_4);
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
+
+#line 395 "root_numpy/src/tree.pyx"
+        __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
+
+        /* "root_numpy/src/tree.pyx":394
+ *                 file.Close()
+ *             if chain.Add(fn, -1) == 0:
+ *                 raise IOError("unable to access tree '{0}' in {1}".format(             # <<<<<<<<<<<<<<
+ *                     treename, fn))
+ *         if chain.GetNtrees() == 0:
+ */
+
+#line 394 "root_numpy/src/tree.pyx"
+        __pyx_t_9 = PyTuple_New(1); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 394; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 394 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_9);
+
+#line 394 "root_numpy/src/tree.pyx"
+        PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_4);
+
+#line 394 "root_numpy/src/tree.pyx"
+        __Pyx_GIVEREF(__pyx_t_4);
+
+#line 394 "root_numpy/src/tree.pyx"
+        __pyx_t_4 = 0;
+
+#line 394 "root_numpy/src/tree.pyx"
+        __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_9, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 394; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 394 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_4);
+
+#line 394 "root_numpy/src/tree.pyx"
+        __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
+
+#line 394 "root_numpy/src/tree.pyx"
+        __Pyx_Raise(__pyx_t_4, 0, 0, 0);
+
+#line 394 "root_numpy/src/tree.pyx"
+        __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+
+#line 394 "root_numpy/src/tree.pyx"
+        {__pyx_filename = __pyx_f[2]; __pyx_lineno = 394; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 394 "root_numpy/src/tree.pyx"
+      }
+
+      /* "root_numpy/src/tree.pyx":379
+ *     try:
+ *         chain = new TChain(treename.c_str())
+ *         for fn in fnames:             # <<<<<<<<<<<<<<
+ *             if warn_missing_tree:
+ *                 file = Open(fn, 'read')
+ */
+
+#line 379 "root_numpy/src/tree.pyx"
+      __pyx_L6_continue:;
+
+#line 379 "root_numpy/src/tree.pyx"
     }
 
-#line 377 "root_numpy/src/tree.pyx"
+#line 379 "root_numpy/src/tree.pyx"
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "root_numpy/src/tree.pyx":383
+    /* "root_numpy/src/tree.pyx":396
+ *                 raise IOError("unable to access tree '{0}' in {1}".format(
+ *                     treename, fn))
+ *         if chain.GetNtrees() == 0:             # <<<<<<<<<<<<<<
+ *             raise IOError("none of the input files contain "
+ *                           "the requested tree '{0}'".format(treename))
+ */
+
+#line 396 "root_numpy/src/tree.pyx"
+    __pyx_t_5 = ((__pyx_v_chain->GetNtrees() == 0) != 0);
+
+#line 396 "root_numpy/src/tree.pyx"
+    if (__pyx_t_5) {
+
+      /* "root_numpy/src/tree.pyx":398
+ *         if chain.GetNtrees() == 0:
+ *             raise IOError("none of the input files contain "
+ *                           "the requested tree '{0}'".format(treename))             # <<<<<<<<<<<<<<
  *         ret = tree2array(
- *             <TTree*> ttree, branches,
+ *             <TTree*> chain, True, branches,
+ */
+
+#line 398 "root_numpy/src/tree.pyx"
+      __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_none_of_the_input_files_contain, __pyx_n_s_format); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 398; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 398 "root_numpy/src/tree.pyx"
+      __Pyx_GOTREF(__pyx_t_4);
+
+#line 398 "root_numpy/src/tree.pyx"
+      __pyx_t_9 = __pyx_convert_PyStr_string_to_py_std__string(__pyx_v_treename); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 398; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 398 "root_numpy/src/tree.pyx"
+      __Pyx_GOTREF(__pyx_t_9);
+
+#line 398 "root_numpy/src/tree.pyx"
+      __pyx_t_8 = NULL;
+
+#line 398 "root_numpy/src/tree.pyx"
+      if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_4))) {
+
+#line 398 "root_numpy/src/tree.pyx"
+        __pyx_t_8 = PyMethod_GET_SELF(__pyx_t_4);
+
+#line 398 "root_numpy/src/tree.pyx"
+        if (likely(__pyx_t_8)) {
+
+#line 398 "root_numpy/src/tree.pyx"
+          PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_4);
+
+#line 398 "root_numpy/src/tree.pyx"
+          __Pyx_INCREF(__pyx_t_8);
+
+#line 398 "root_numpy/src/tree.pyx"
+          __Pyx_INCREF(function);
+
+#line 398 "root_numpy/src/tree.pyx"
+          __Pyx_DECREF_SET(__pyx_t_4, function);
+
+#line 398 "root_numpy/src/tree.pyx"
+        }
+
+#line 398 "root_numpy/src/tree.pyx"
+      }
+
+#line 398 "root_numpy/src/tree.pyx"
+      if (!__pyx_t_8) {
+
+#line 398 "root_numpy/src/tree.pyx"
+        __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_9); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 398; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 398 "root_numpy/src/tree.pyx"
+        __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
+
+#line 398 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_1);
+
+#line 398 "root_numpy/src/tree.pyx"
+      } else {
+
+#line 398 "root_numpy/src/tree.pyx"
+        __pyx_t_13 = PyTuple_New(1+1); if (unlikely(!__pyx_t_13)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 398; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 398 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_13);
+
+#line 398 "root_numpy/src/tree.pyx"
+        PyTuple_SET_ITEM(__pyx_t_13, 0, __pyx_t_8); __Pyx_GIVEREF(__pyx_t_8); __pyx_t_8 = NULL;
+
+#line 398 "root_numpy/src/tree.pyx"
+        PyTuple_SET_ITEM(__pyx_t_13, 0+1, __pyx_t_9);
+
+#line 398 "root_numpy/src/tree.pyx"
+        __Pyx_GIVEREF(__pyx_t_9);
+
+#line 398 "root_numpy/src/tree.pyx"
+        __pyx_t_9 = 0;
+
+#line 398 "root_numpy/src/tree.pyx"
+        __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_13, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 398; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 398 "root_numpy/src/tree.pyx"
+        __Pyx_GOTREF(__pyx_t_1);
+
+#line 398 "root_numpy/src/tree.pyx"
+        __Pyx_DECREF(__pyx_t_13); __pyx_t_13 = 0;
+
+#line 398 "root_numpy/src/tree.pyx"
+      }
+
+#line 398 "root_numpy/src/tree.pyx"
+      __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+
+      /* "root_numpy/src/tree.pyx":397
+ *                     treename, fn))
+ *         if chain.GetNtrees() == 0:
+ *             raise IOError("none of the input files contain "             # <<<<<<<<<<<<<<
+ *                           "the requested tree '{0}'".format(treename))
+ *         ret = tree2array(
+ */
+
+#line 397 "root_numpy/src/tree.pyx"
+      __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 397; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 397 "root_numpy/src/tree.pyx"
+      __Pyx_GOTREF(__pyx_t_4);
+
+#line 397 "root_numpy/src/tree.pyx"
+      PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_1);
+
+#line 397 "root_numpy/src/tree.pyx"
+      __Pyx_GIVEREF(__pyx_t_1);
+
+#line 397 "root_numpy/src/tree.pyx"
+      __pyx_t_1 = 0;
+
+#line 397 "root_numpy/src/tree.pyx"
+      __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 397; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 397 "root_numpy/src/tree.pyx"
+      __Pyx_GOTREF(__pyx_t_1);
+
+#line 397 "root_numpy/src/tree.pyx"
+      __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+
+#line 397 "root_numpy/src/tree.pyx"
+      __Pyx_Raise(__pyx_t_1, 0, 0, 0);
+
+#line 397 "root_numpy/src/tree.pyx"
+      __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+
+#line 397 "root_numpy/src/tree.pyx"
+      {__pyx_filename = __pyx_f[2]; __pyx_lineno = 397; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+
+#line 397 "root_numpy/src/tree.pyx"
+    }
+
+    /* "root_numpy/src/tree.pyx":401
+ *         ret = tree2array(
+ *             <TTree*> chain, True, branches,
  *             selection or '', start, stop, step,             # <<<<<<<<<<<<<<
  *             include_weight, weight_name, cache_size)
  *     finally:
  */
 
-#line 383 "root_numpy/src/tree.pyx"
-    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_v_selection); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 401 "root_numpy/src/tree.pyx"
+    __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_selection); if (unlikely(__pyx_t_5 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 401; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 383 "root_numpy/src/tree.pyx"
-    if (!__pyx_t_6) {
+#line 401 "root_numpy/src/tree.pyx"
+    if (!__pyx_t_5) {
 
-#line 383 "root_numpy/src/tree.pyx"
+#line 401 "root_numpy/src/tree.pyx"
     } else {
 
-#line 383 "root_numpy/src/tree.pyx"
-      __pyx_t_13 = __pyx_convert_string_from_py_std__string(__pyx_v_selection); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 401 "root_numpy/src/tree.pyx"
+      __pyx_t_15 = __pyx_convert_string_from_py_std__string(__pyx_v_selection); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 401; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 383 "root_numpy/src/tree.pyx"
-      __pyx_t_12 = __pyx_t_13;
+#line 401 "root_numpy/src/tree.pyx"
+      __pyx_t_14 = __pyx_t_15;
 
-#line 383 "root_numpy/src/tree.pyx"
-      goto __pyx_L9_bool_binop_done;
+#line 401 "root_numpy/src/tree.pyx"
+      goto __pyx_L13_bool_binop_done;
 
-#line 383 "root_numpy/src/tree.pyx"
+#line 401 "root_numpy/src/tree.pyx"
     }
 
-#line 383 "root_numpy/src/tree.pyx"
-    __pyx_t_13 = __pyx_convert_string_from_py_std__string(__pyx_kp_s__33); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 383; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 401 "root_numpy/src/tree.pyx"
+    __pyx_t_15 = __pyx_convert_string_from_py_std__string(__pyx_kp_s__33); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 401; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 383 "root_numpy/src/tree.pyx"
-    __pyx_t_12 = __pyx_t_13;
+#line 401 "root_numpy/src/tree.pyx"
+    __pyx_t_14 = __pyx_t_15;
 
-#line 383 "root_numpy/src/tree.pyx"
-    __pyx_L9_bool_binop_done:;
+#line 401 "root_numpy/src/tree.pyx"
+    __pyx_L13_bool_binop_done:;
 
-    /* "root_numpy/src/tree.pyx":381
- *                 raise IOError("unable to access tree '{0}' in {1}".format(
- *                     treename, fn))
+    /* "root_numpy/src/tree.pyx":399
+ *             raise IOError("none of the input files contain "
+ *                           "the requested tree '{0}'".format(treename))
  *         ret = tree2array(             # <<<<<<<<<<<<<<
- *             <TTree*> ttree, branches,
+ *             <TTree*> chain, True, branches,
  *             selection or '', start, stop, step,
  */
 
-#line 381 "root_numpy/src/tree.pyx"
-    __pyx_t_1 = __pyx_f_13_librootnumpy_tree2array(((TTree *)__pyx_v_ttree), __pyx_v_branches, __pyx_t_12, __pyx_v_start, __pyx_v_stop, __pyx_v_step, __pyx_v_include_weight, __pyx_v_weight_name, __pyx_v_cache_size); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 381; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
+#line 399 "root_numpy/src/tree.pyx"
+    __pyx_t_1 = __pyx_f_13_librootnumpy_tree2array(((TTree *)__pyx_v_chain), 1, __pyx_v_branches, __pyx_t_14, __pyx_v_start, __pyx_v_stop, __pyx_v_step, __pyx_v_include_weight, __pyx_v_weight_name, __pyx_v_cache_size); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 399; __pyx_clineno = __LINE__; goto __pyx_L4_error;}
 
-#line 381 "root_numpy/src/tree.pyx"
+#line 399 "root_numpy/src/tree.pyx"
     __Pyx_GOTREF(__pyx_t_1);
 
-#line 381 "root_numpy/src/tree.pyx"
+#line 399 "root_numpy/src/tree.pyx"
     __pyx_v_ret = __pyx_t_1;
 
-#line 381 "root_numpy/src/tree.pyx"
+#line 399 "root_numpy/src/tree.pyx"
     __pyx_t_1 = 0;
 
-#line 381 "root_numpy/src/tree.pyx"
+#line 399 "root_numpy/src/tree.pyx"
   }
 
-  /* "root_numpy/src/tree.pyx":386
+  /* "root_numpy/src/tree.pyx":404
  *             include_weight, weight_name, cache_size)
  *     finally:
- *         del ttree             # <<<<<<<<<<<<<<
+ *         del chain             # <<<<<<<<<<<<<<
  *     return ret
  * 
  */
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
   /*finally:*/ {
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
     /*normal exit:*/{
 
-#line 386 "root_numpy/src/tree.pyx"
-      delete __pyx_v_ttree;
+#line 404 "root_numpy/src/tree.pyx"
+      delete __pyx_v_chain;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       goto __pyx_L5;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
     }
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
     /*exception exit:*/{
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __pyx_L4_error:;
 
-#line 386 "root_numpy/src/tree.pyx"
-      __pyx_t_17 = 0; __pyx_t_18 = 0; __pyx_t_19 = 0; __pyx_t_20 = 0; __pyx_t_21 = 0; __pyx_t_22 = 0;
+#line 404 "root_numpy/src/tree.pyx"
+      __pyx_t_19 = 0; __pyx_t_20 = 0; __pyx_t_21 = 0; __pyx_t_22 = 0; __pyx_t_23 = 0; __pyx_t_24 = 0;
 
-#line 386 "root_numpy/src/tree.pyx"
-      __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
-
-#line 386 "root_numpy/src/tree.pyx"
-      __Pyx_XDECREF(__pyx_t_8); __pyx_t_8 = 0;
-
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_11); __pyx_t_11 = 0;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XDECREF(__pyx_t_10); __pyx_t_10 = 0;
+
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XDECREF(__pyx_t_8); __pyx_t_8 = 0;
+
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
+
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XDECREF(__pyx_t_13); __pyx_t_13 = 0;
+
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-#line 386 "root_numpy/src/tree.pyx"
-      if (PY_MAJOR_VERSION >= 3) __Pyx_ExceptionSwap(&__pyx_t_20, &__pyx_t_21, &__pyx_t_22);
+#line 404 "root_numpy/src/tree.pyx"
+      if (PY_MAJOR_VERSION >= 3) __Pyx_ExceptionSwap(&__pyx_t_22, &__pyx_t_23, &__pyx_t_24);
 
-#line 386 "root_numpy/src/tree.pyx"
-      if ((PY_MAJOR_VERSION < 3) || unlikely(__Pyx_GetException(&__pyx_t_17, &__pyx_t_18, &__pyx_t_19) < 0)) __Pyx_ErrFetch(&__pyx_t_17, &__pyx_t_18, &__pyx_t_19);
+#line 404 "root_numpy/src/tree.pyx"
+      if ((PY_MAJOR_VERSION < 3) || unlikely(__Pyx_GetException(&__pyx_t_19, &__pyx_t_20, &__pyx_t_21) < 0)) __Pyx_ErrFetch(&__pyx_t_19, &__pyx_t_20, &__pyx_t_21);
 
-#line 386 "root_numpy/src/tree.pyx"
-      __Pyx_XGOTREF(__pyx_t_17);
-
-#line 386 "root_numpy/src/tree.pyx"
-      __Pyx_XGOTREF(__pyx_t_18);
-
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_19);
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_20);
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_21);
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_22);
 
-#line 386 "root_numpy/src/tree.pyx"
-      __pyx_t_14 = __pyx_lineno; __pyx_t_15 = __pyx_clineno; __pyx_t_16 = __pyx_filename;
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XGOTREF(__pyx_t_23);
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XGOTREF(__pyx_t_24);
+
+#line 404 "root_numpy/src/tree.pyx"
+      __pyx_t_16 = __pyx_lineno; __pyx_t_17 = __pyx_clineno; __pyx_t_18 = __pyx_filename;
+
+#line 404 "root_numpy/src/tree.pyx"
       {
 
-#line 386 "root_numpy/src/tree.pyx"
-        delete __pyx_v_ttree;
+#line 404 "root_numpy/src/tree.pyx"
+        delete __pyx_v_chain;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       }
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       if (PY_MAJOR_VERSION >= 3) {
 
-#line 386 "root_numpy/src/tree.pyx"
-        __Pyx_XGIVEREF(__pyx_t_20);
-
-#line 386 "root_numpy/src/tree.pyx"
-        __Pyx_XGIVEREF(__pyx_t_21);
-
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
         __Pyx_XGIVEREF(__pyx_t_22);
 
-#line 386 "root_numpy/src/tree.pyx"
-        __Pyx_ExceptionReset(__pyx_t_20, __pyx_t_21, __pyx_t_22);
+#line 404 "root_numpy/src/tree.pyx"
+        __Pyx_XGIVEREF(__pyx_t_23);
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
+        __Pyx_XGIVEREF(__pyx_t_24);
+
+#line 404 "root_numpy/src/tree.pyx"
+        __Pyx_ExceptionReset(__pyx_t_22, __pyx_t_23, __pyx_t_24);
+
+#line 404 "root_numpy/src/tree.pyx"
       }
 
-#line 386 "root_numpy/src/tree.pyx"
-      __Pyx_XGIVEREF(__pyx_t_17);
-
-#line 386 "root_numpy/src/tree.pyx"
-      __Pyx_XGIVEREF(__pyx_t_18);
-
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
       __Pyx_XGIVEREF(__pyx_t_19);
 
-#line 386 "root_numpy/src/tree.pyx"
-      __Pyx_ErrRestore(__pyx_t_17, __pyx_t_18, __pyx_t_19);
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XGIVEREF(__pyx_t_20);
 
-#line 386 "root_numpy/src/tree.pyx"
-      __pyx_t_17 = 0; __pyx_t_18 = 0; __pyx_t_19 = 0; __pyx_t_20 = 0; __pyx_t_21 = 0; __pyx_t_22 = 0;
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_XGIVEREF(__pyx_t_21);
 
-#line 386 "root_numpy/src/tree.pyx"
-      __pyx_lineno = __pyx_t_14; __pyx_clineno = __pyx_t_15; __pyx_filename = __pyx_t_16;
+#line 404 "root_numpy/src/tree.pyx"
+      __Pyx_ErrRestore(__pyx_t_19, __pyx_t_20, __pyx_t_21);
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
+      __pyx_t_19 = 0; __pyx_t_20 = 0; __pyx_t_21 = 0; __pyx_t_22 = 0; __pyx_t_23 = 0; __pyx_t_24 = 0;
+
+#line 404 "root_numpy/src/tree.pyx"
+      __pyx_lineno = __pyx_t_16; __pyx_clineno = __pyx_t_17; __pyx_filename = __pyx_t_18;
+
+#line 404 "root_numpy/src/tree.pyx"
       goto __pyx_L1_error;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
     }
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
     __pyx_L5:;
 
-#line 386 "root_numpy/src/tree.pyx"
+#line 404 "root_numpy/src/tree.pyx"
   }
 
-  /* "root_numpy/src/tree.pyx":387
+  /* "root_numpy/src/tree.pyx":405
  *     finally:
- *         del ttree
+ *         del chain
  *     return ret             # <<<<<<<<<<<<<<
  * 
  * 
  */
 
-#line 387 "root_numpy/src/tree.pyx"
+#line 405 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_r);
 
-#line 387 "root_numpy/src/tree.pyx"
+#line 405 "root_numpy/src/tree.pyx"
   __Pyx_INCREF(__pyx_v_ret);
 
-#line 387 "root_numpy/src/tree.pyx"
+#line 405 "root_numpy/src/tree.pyx"
   __pyx_r = __pyx_v_ret;
 
-#line 387 "root_numpy/src/tree.pyx"
+#line 405 "root_numpy/src/tree.pyx"
   goto __pyx_L0;
 
   /* "root_numpy/src/tree.pyx":370
@@ -21072,7 +21757,13 @@ __pyx_t_1 = PyObject_GetIter(__pyx_v_fnames); if (unlikely(!__pyx_t_1)) {__pyx_f
   __Pyx_XDECREF(__pyx_t_9);
 
 #line 370 "root_numpy/src/tree.pyx"
+  __Pyx_XDECREF(__pyx_t_10);
+
+#line 370 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_11);
+
+#line 370 "root_numpy/src/tree.pyx"
+  __Pyx_XDECREF(__pyx_t_13);
 
 #line 370 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.root2array_fromfile", __pyx_clineno, __pyx_lineno, __pyx_filename);
@@ -21101,7 +21792,7 @@ __pyx_t_1 = PyObject_GetIter(__pyx_v_fnames); if (unlikely(!__pyx_t_1)) {__pyx_f
 #line 370 "root_numpy/src/tree.pyx"
 }
 
-/* "root_numpy/src/tree.pyx":390
+/* "root_numpy/src/tree.pyx":408
  * 
  * 
  * def root2array_fromtree(tree, branches, selection,             # <<<<<<<<<<<<<<
@@ -21109,385 +21800,385 @@ __pyx_t_1 = PyObject_GetIter(__pyx_v_fnames); if (unlikely(!__pyx_t_1)) {__pyx_f
  *                         bool include_weight, string weight_name,
  */
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 /* Python wrapper */
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pw_13_librootnumpy_11root2array_fromtree(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
 static PyMethodDef __pyx_mdef_13_librootnumpy_11root2array_fromtree = 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 {"root2array_fromtree", (PyCFunction)__pyx_pw_13_librootnumpy_11root2array_fromtree, METH_VARARGS|METH_KEYWORDS, 0};
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pw_13_librootnumpy_11root2array_fromtree(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_tree = 0
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_branches = 0
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_selection = 0
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_start = 0
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_stop = 0
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_step = 0
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   bool __pyx_v_include_weight
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   std::string __pyx_v_weight_name
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   long __pyx_v_cache_size
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 ;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   PyObject *__pyx_r = 0;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyDeclarations
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_RefNannySetupContext("root2array_fromtree (wrapper)", 0);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   {
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_tree,&__pyx_n_s_branches,&__pyx_n_s_selection,&__pyx_n_s_start,&__pyx_n_s_stop,&__pyx_n_s_step,&__pyx_n_s_include_weight,&__pyx_n_s_weight_name,&__pyx_n_s_cache_size,0};
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     PyObject* values[9] = {0,0,0,0,0,0,0,0,0};
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     if (unlikely(__pyx_kwds)) {
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       Py_ssize_t kw_args;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       const Py_ssize_t pos_args = PyTuple_GET_SIZE(__pyx_args);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       switch (pos_args) {
         case  9: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[8] = PyTuple_GET_ITEM(__pyx_args, 8);
         case  8: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[7] = PyTuple_GET_ITEM(__pyx_args, 7);
         case  7: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[6] = PyTuple_GET_ITEM(__pyx_args, 6);
         case  6: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[5] = PyTuple_GET_ITEM(__pyx_args, 5);
         case  5: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[4] = PyTuple_GET_ITEM(__pyx_args, 4);
         case  4: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
         case  3: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
         case  2: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
         case  1: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  0: break;
         default: 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       kw_args = PyDict_Size(__pyx_kwds);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       switch (pos_args) {
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  0:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[0] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_tree)) != 0)) kw_args--;
         else 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  1:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_branches)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 1); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  2:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_selection)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 2); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  3:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_start)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 3); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  4:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_stop)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 4); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  5:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_step)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 5); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  6:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_include_weight)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 6); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  7:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[7] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_weight_name)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 7); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         case  8:
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         if (likely((values[8] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_cache_size)) != 0)) kw_args--;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, 8); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
         }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       if (unlikely(kw_args > 0)) {
 
-#line 390 "root_numpy/src/tree.pyx"
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "root2array_fromtree") < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "root2array_fromtree") < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     } else if (PyTuple_GET_SIZE(__pyx_args) != 9) {
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       goto __pyx_L5_argtuple_error;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     } else {
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[4] = PyTuple_GET_ITEM(__pyx_args, 4);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[5] = PyTuple_GET_ITEM(__pyx_args, 5);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[6] = PyTuple_GET_ITEM(__pyx_args, 6);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[7] = PyTuple_GET_ITEM(__pyx_args, 7);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
       values[8] = PyTuple_GET_ITEM(__pyx_args, 8);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     __pyx_v_tree = values[0];
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     __pyx_v_branches = values[1];
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     __pyx_v_selection = values[2];
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     __pyx_v_start = values[3];
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     __pyx_v_stop = values[4];
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
     __pyx_v_step = values[5];
 
-#line 390 "root_numpy/src/tree.pyx"
-    __pyx_v_include_weight = __Pyx_PyObject_IsTrue(values[6]); if (unlikely((__pyx_v_include_weight == (bool)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 392; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+    __pyx_v_include_weight = __Pyx_PyObject_IsTrue(values[6]); if (unlikely((__pyx_v_include_weight == (bool)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 410; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
-    __pyx_v_weight_name = __pyx_convert_string_from_py_std__string(values[7]); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 392; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+    __pyx_v_weight_name = __pyx_convert_string_from_py_std__string(values[7]); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 410; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
-    __pyx_v_cache_size = __Pyx_PyInt_As_long(values[8]); if (unlikely((__pyx_v_cache_size == (long)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 393; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+    __pyx_v_cache_size = __Pyx_PyInt_As_long(values[8]); if (unlikely((__pyx_v_cache_size == (long)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 411; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   goto __pyx_L4_argument_unpacking_done;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __pyx_L5_argtuple_error:;
   __Pyx_RaiseArgtupleInvalid("root2array_fromtree", 1, 9, 9, PyTuple_GET_SIZE(__pyx_args)); 
-#line 390 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 408 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __pyx_L3_error:;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.root2array_fromtree", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   return NULL;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __pyx_L4_argument_unpacking_done:;
   __pyx_r = 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 __pyx_pf_13_librootnumpy_10root2array_fromtree(__pyx_self, __pyx_v_tree, __pyx_v_branches, __pyx_v_selection, __pyx_v_start, __pyx_v_stop, __pyx_v_step, __pyx_v_include_weight, __pyx_v_weight_name, __pyx_v_cache_size);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   /* function exit code */
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   return __pyx_r;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 }
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pf_13_librootnumpy_10root2array_fromtree(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_tree, PyObject *__pyx_v_branches, PyObject *__pyx_v_selection, PyObject *__pyx_v_start, PyObject *__pyx_v_stop, PyObject *__pyx_v_step, bool __pyx_v_include_weight, std::string __pyx_v_weight_name, long __pyx_v_cache_size) {
-  TTree *__pyx_v_chain
-#line 390 "root_numpy/src/tree.pyx"
+  TTree *__pyx_v_rtree
+#line 408 "root_numpy/src/tree.pyx"
 ;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   void *__pyx_t_1;
@@ -21499,96 +22190,96 @@ static PyObject *__pyx_pf_13_librootnumpy_10root2array_fromtree(CYTHON_UNUSED Py
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_RefNannySetupContext("root2array_fromtree", 0);
 
-  /* "root_numpy/src/tree.pyx":394
+  /* "root_numpy/src/tree.pyx":412
  *                         bool include_weight, string weight_name,
  *                         long cache_size):
- *     cdef TTree* chain = <TTree*> PyCObject_AsVoidPtr(tree)             # <<<<<<<<<<<<<<
+ *     cdef TTree* rtree = <TTree*> PyCObject_AsVoidPtr(tree)             # <<<<<<<<<<<<<<
  *     return tree2array(
- *         chain, branches,
+ *         rtree, False, branches,
  */
 
-#line 394 "root_numpy/src/tree.pyx"
-  __pyx_t_1 = PyCObject_AsVoidPtr(__pyx_v_tree); if (unlikely(__pyx_t_1 == NULL && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 394; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 412 "root_numpy/src/tree.pyx"
+  __pyx_t_1 = PyCObject_AsVoidPtr(__pyx_v_tree); if (unlikely(__pyx_t_1 == NULL && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 412; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 394 "root_numpy/src/tree.pyx"
-  __pyx_v_chain = ((TTree *)__pyx_t_1);
+#line 412 "root_numpy/src/tree.pyx"
+  __pyx_v_rtree = ((TTree *)__pyx_t_1);
 
-  /* "root_numpy/src/tree.pyx":395
+  /* "root_numpy/src/tree.pyx":413
  *                         long cache_size):
- *     cdef TTree* chain = <TTree*> PyCObject_AsVoidPtr(tree)
+ *     cdef TTree* rtree = <TTree*> PyCObject_AsVoidPtr(tree)
  *     return tree2array(             # <<<<<<<<<<<<<<
- *         chain, branches,
+ *         rtree, False, branches,
  *         selection or '', start, stop, step,
  */
 
-#line 395 "root_numpy/src/tree.pyx"
+#line 413 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_r);
 
-  /* "root_numpy/src/tree.pyx":397
+  /* "root_numpy/src/tree.pyx":415
  *     return tree2array(
- *         chain, branches,
+ *         rtree, False, branches,
  *         selection or '', start, stop, step,             # <<<<<<<<<<<<<<
  *         include_weight, weight_name, cache_size)
  * 
  */
 
-#line 397 "root_numpy/src/tree.pyx"
-  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_v_selection); if (unlikely(__pyx_t_3 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 397; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 415 "root_numpy/src/tree.pyx"
+  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_v_selection); if (unlikely(__pyx_t_3 < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 415; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 397 "root_numpy/src/tree.pyx"
+#line 415 "root_numpy/src/tree.pyx"
   if (!__pyx_t_3) {
 
-#line 397 "root_numpy/src/tree.pyx"
+#line 415 "root_numpy/src/tree.pyx"
   } else {
 
-#line 397 "root_numpy/src/tree.pyx"
-    __pyx_t_4 = __pyx_convert_string_from_py_std__string(__pyx_v_selection); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 397; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 415 "root_numpy/src/tree.pyx"
+    __pyx_t_4 = __pyx_convert_string_from_py_std__string(__pyx_v_selection); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 415; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 397 "root_numpy/src/tree.pyx"
+#line 415 "root_numpy/src/tree.pyx"
     __pyx_t_2 = __pyx_t_4;
 
-#line 397 "root_numpy/src/tree.pyx"
+#line 415 "root_numpy/src/tree.pyx"
     goto __pyx_L3_bool_binop_done;
 
-#line 397 "root_numpy/src/tree.pyx"
+#line 415 "root_numpy/src/tree.pyx"
   }
 
-#line 397 "root_numpy/src/tree.pyx"
-  __pyx_t_4 = __pyx_convert_string_from_py_std__string(__pyx_kp_s__33); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 397; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 415 "root_numpy/src/tree.pyx"
+  __pyx_t_4 = __pyx_convert_string_from_py_std__string(__pyx_kp_s__33); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 415; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 397 "root_numpy/src/tree.pyx"
+#line 415 "root_numpy/src/tree.pyx"
   __pyx_t_2 = __pyx_t_4;
 
-#line 397 "root_numpy/src/tree.pyx"
+#line 415 "root_numpy/src/tree.pyx"
   __pyx_L3_bool_binop_done:;
 
-  /* "root_numpy/src/tree.pyx":395
+  /* "root_numpy/src/tree.pyx":413
  *                         long cache_size):
- *     cdef TTree* chain = <TTree*> PyCObject_AsVoidPtr(tree)
+ *     cdef TTree* rtree = <TTree*> PyCObject_AsVoidPtr(tree)
  *     return tree2array(             # <<<<<<<<<<<<<<
- *         chain, branches,
+ *         rtree, False, branches,
  *         selection or '', start, stop, step,
  */
 
-#line 395 "root_numpy/src/tree.pyx"
-  __pyx_t_5 = __pyx_f_13_librootnumpy_tree2array(__pyx_v_chain, __pyx_v_branches, __pyx_t_2, __pyx_v_start, __pyx_v_stop, __pyx_v_step, __pyx_v_include_weight, __pyx_v_weight_name, __pyx_v_cache_size); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 395; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 413 "root_numpy/src/tree.pyx"
+  __pyx_t_5 = __pyx_f_13_librootnumpy_tree2array(__pyx_v_rtree, 0, __pyx_v_branches, __pyx_t_2, __pyx_v_start, __pyx_v_stop, __pyx_v_step, __pyx_v_include_weight, __pyx_v_weight_name, __pyx_v_cache_size); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 413; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 395 "root_numpy/src/tree.pyx"
+#line 413 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_t_5);
 
-#line 395 "root_numpy/src/tree.pyx"
+#line 413 "root_numpy/src/tree.pyx"
   __pyx_r = __pyx_t_5;
 
-#line 395 "root_numpy/src/tree.pyx"
+#line 413 "root_numpy/src/tree.pyx"
   __pyx_t_5 = 0;
 
-#line 395 "root_numpy/src/tree.pyx"
+#line 413 "root_numpy/src/tree.pyx"
   goto __pyx_L0;
 
-  /* "root_numpy/src/tree.pyx":390
+  /* "root_numpy/src/tree.pyx":408
  * 
  * 
  * def root2array_fromtree(tree, branches, selection,             # <<<<<<<<<<<<<<
@@ -21596,40 +22287,40 @@ static PyObject *__pyx_pf_13_librootnumpy_10root2array_fromtree(CYTHON_UNUSED Py
  *                         bool include_weight, string weight_name,
  */
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   /* function exit code */
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __pyx_L1_error:;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_5);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.root2array_fromtree", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __pyx_r = NULL;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __pyx_L0:;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   return __pyx_r;
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
 }
 
-/* "root_numpy/src/tree.pyx":401
+/* "root_numpy/src/tree.pyx":419
  * 
  * 
  * cdef TTree* array2tree(np.ndarray arr, string name='tree', TTree* tree=NULL) except *:             # <<<<<<<<<<<<<<
@@ -21637,61 +22328,61 @@ static PyObject *__pyx_pf_13_librootnumpy_10root2array_fromtree(CYTHON_UNUSED Py
  *     cdef NP2ROOTConverter* cvt
  */
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, struct __pyx_opt_args_13_librootnumpy_array2tree *__pyx_optional_args) {
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   std::string __pyx_v_name = __pyx_k__34;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   TTree *__pyx_v_tree = ((TTree *)NULL);
   std::vector<__pyx_t_13_librootnumpy_NP2ROOTConverter *>  __pyx_v_converters
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   __pyx_t_13_librootnumpy_NP2ROOTConverter *__pyx_v_cvt
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   std::vector<int>  __pyx_v_roffsetarray
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   int __pyx_v_roffset
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   unsigned int __pyx_v_icol
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   unsigned int __pyx_v_num_cols
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   __pyx_t_13_librootnumpy_SIZE_t __pyx_v_arr_len
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   __pyx_t_13_librootnumpy_SIZE_t __pyx_v_idata
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   void *__pyx_v_source
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   void *__pyx_v_thisrow
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_fieldnames = NULL
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_fields = NULL
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_fieldname = NULL
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_dtype = NULL
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 ;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   TTree *__pyx_r;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -21721,34 +22412,34 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_RefNannySetupContext("array2tree", 0);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   if (__pyx_optional_args) {
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
     if (__pyx_optional_args->__pyx_n > 0) {
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
       __pyx_v_name = __pyx_optional_args->name;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
       if (__pyx_optional_args->__pyx_n > 1) {
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
         __pyx_v_tree = __pyx_optional_args->tree;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
       }
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
     }
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   }
 
-  /* "root_numpy/src/tree.pyx":408
+  /* "root_numpy/src/tree.pyx":426
  *     cdef unsigned int icol
  *     cdef unsigned int num_cols
  *     cdef SIZE_t arr_len = arr.shape[0]             # <<<<<<<<<<<<<<
@@ -21756,10 +22447,10 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *     cdef void* source = NULL
  */
 
-#line 408 "root_numpy/src/tree.pyx"
+#line 426 "root_numpy/src/tree.pyx"
   __pyx_v_arr_len = (__pyx_v_arr->dimensions[0]);
 
-  /* "root_numpy/src/tree.pyx":410
+  /* "root_numpy/src/tree.pyx":428
  *     cdef SIZE_t arr_len = arr.shape[0]
  *     cdef SIZE_t idata
  *     cdef void* source = NULL             # <<<<<<<<<<<<<<
@@ -21767,10 +22458,10 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  * 
  */
 
-#line 410 "root_numpy/src/tree.pyx"
+#line 428 "root_numpy/src/tree.pyx"
   __pyx_v_source = NULL;
 
-  /* "root_numpy/src/tree.pyx":411
+  /* "root_numpy/src/tree.pyx":429
  *     cdef SIZE_t idata
  *     cdef void* source = NULL
  *     cdef void* thisrow = NULL             # <<<<<<<<<<<<<<
@@ -21778,10 +22469,10 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *     try:
  */
 
-#line 411 "root_numpy/src/tree.pyx"
+#line 429 "root_numpy/src/tree.pyx"
   __pyx_v_thisrow = NULL;
 
-  /* "root_numpy/src/tree.pyx":413
+  /* "root_numpy/src/tree.pyx":431
  *     cdef void* thisrow = NULL
  * 
  *     try:             # <<<<<<<<<<<<<<
@@ -21789,20 +22480,20 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *             tree = new TTree(name.c_str(), name.c_str())
  */
 
-#line 413 "root_numpy/src/tree.pyx"
+#line 431 "root_numpy/src/tree.pyx"
   /*try:*/ {
 
-#line 413 "root_numpy/src/tree.pyx"
+#line 431 "root_numpy/src/tree.pyx"
     {
       __Pyx_ExceptionSave(&__pyx_t_1, &__pyx_t_2, &__pyx_t_3);
       __Pyx_XGOTREF(__pyx_t_1);
       __Pyx_XGOTREF(__pyx_t_2);
       __Pyx_XGOTREF(__pyx_t_3);
 
-#line 413 "root_numpy/src/tree.pyx"
+#line 431 "root_numpy/src/tree.pyx"
       /*try:*/ {
 
-        /* "root_numpy/src/tree.pyx":414
+        /* "root_numpy/src/tree.pyx":432
  * 
  *     try:
  *         if tree == NULL:             # <<<<<<<<<<<<<<
@@ -21810,13 +22501,13 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  * 
  */
 
-#line 414 "root_numpy/src/tree.pyx"
+#line 432 "root_numpy/src/tree.pyx"
         __pyx_t_4 = ((__pyx_v_tree == NULL) != 0);
 
-#line 414 "root_numpy/src/tree.pyx"
+#line 432 "root_numpy/src/tree.pyx"
         if (__pyx_t_4) {
 
-          /* "root_numpy/src/tree.pyx":415
+          /* "root_numpy/src/tree.pyx":433
  *     try:
  *         if tree == NULL:
  *             tree = new TTree(name.c_str(), name.c_str())             # <<<<<<<<<<<<<<
@@ -21824,19 +22515,19 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *         fieldnames = arr.dtype.names
  */
 
-#line 415 "root_numpy/src/tree.pyx"
+#line 433 "root_numpy/src/tree.pyx"
           __pyx_v_tree = new TTree(__pyx_v_name.c_str(), __pyx_v_name.c_str());
 
-#line 415 "root_numpy/src/tree.pyx"
+#line 433 "root_numpy/src/tree.pyx"
           goto __pyx_L14;
 
-#line 415 "root_numpy/src/tree.pyx"
+#line 433 "root_numpy/src/tree.pyx"
         }
 
-#line 415 "root_numpy/src/tree.pyx"
+#line 433 "root_numpy/src/tree.pyx"
         __pyx_L14:;
 
-        /* "root_numpy/src/tree.pyx":417
+        /* "root_numpy/src/tree.pyx":435
  *             tree = new TTree(name.c_str(), name.c_str())
  * 
  *         fieldnames = arr.dtype.names             # <<<<<<<<<<<<<<
@@ -21844,28 +22535,28 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  * 
  */
 
-#line 417 "root_numpy/src/tree.pyx"
-        __pyx_t_5 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_arr), __pyx_n_s_dtype); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 417; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 435 "root_numpy/src/tree.pyx"
+        __pyx_t_5 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_arr), __pyx_n_s_dtype); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 435; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 417 "root_numpy/src/tree.pyx"
+#line 435 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_5);
 
-#line 417 "root_numpy/src/tree.pyx"
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_names); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 417; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 435 "root_numpy/src/tree.pyx"
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_names); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 435; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 417 "root_numpy/src/tree.pyx"
+#line 435 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_6);
 
-#line 417 "root_numpy/src/tree.pyx"
+#line 435 "root_numpy/src/tree.pyx"
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 417 "root_numpy/src/tree.pyx"
+#line 435 "root_numpy/src/tree.pyx"
         __pyx_v_fieldnames = __pyx_t_6;
 
-#line 417 "root_numpy/src/tree.pyx"
+#line 435 "root_numpy/src/tree.pyx"
         __pyx_t_6 = 0;
 
-        /* "root_numpy/src/tree.pyx":418
+        /* "root_numpy/src/tree.pyx":436
  * 
  *         fieldnames = arr.dtype.names
  *         fields = arr.dtype.fields             # <<<<<<<<<<<<<<
@@ -21873,28 +22564,28 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *         # Determine the structure
  */
 
-#line 418 "root_numpy/src/tree.pyx"
-        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_arr), __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 418; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 436 "root_numpy/src/tree.pyx"
+        __pyx_t_6 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_arr), __pyx_n_s_dtype); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 436; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 418 "root_numpy/src/tree.pyx"
+#line 436 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_6);
 
-#line 418 "root_numpy/src/tree.pyx"
-        __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_fields); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 418; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 436 "root_numpy/src/tree.pyx"
+        __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_fields); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 436; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 418 "root_numpy/src/tree.pyx"
+#line 436 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_5);
 
-#line 418 "root_numpy/src/tree.pyx"
+#line 436 "root_numpy/src/tree.pyx"
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-#line 418 "root_numpy/src/tree.pyx"
+#line 436 "root_numpy/src/tree.pyx"
         __pyx_v_fields = __pyx_t_5;
 
-#line 418 "root_numpy/src/tree.pyx"
+#line 436 "root_numpy/src/tree.pyx"
         __pyx_t_5 = 0;
 
-        /* "root_numpy/src/tree.pyx":421
+        /* "root_numpy/src/tree.pyx":439
  * 
  *         # Determine the structure
  *         for icol in range(len(fieldnames)):             # <<<<<<<<<<<<<<
@@ -21902,16 +22593,16 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *             # roffset is an offset of particular field in each record
  */
 
-#line 421 "root_numpy/src/tree.pyx"
-        __pyx_t_7 = PyObject_Length(__pyx_v_fieldnames); if (unlikely(__pyx_t_7 == -1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 421; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 439 "root_numpy/src/tree.pyx"
+        __pyx_t_7 = PyObject_Length(__pyx_v_fieldnames); if (unlikely(__pyx_t_7 == -1)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 439; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 421 "root_numpy/src/tree.pyx"
+#line 439 "root_numpy/src/tree.pyx"
         for (__pyx_t_8 = 0; __pyx_t_8 < __pyx_t_7; __pyx_t_8+=1) {
 
-#line 421 "root_numpy/src/tree.pyx"
+#line 439 "root_numpy/src/tree.pyx"
           __pyx_v_icol = __pyx_t_8;
 
-          /* "root_numpy/src/tree.pyx":422
+          /* "root_numpy/src/tree.pyx":440
  *         # Determine the structure
  *         for icol in range(len(fieldnames)):
  *             fieldname = fieldnames[icol]             # <<<<<<<<<<<<<<
@@ -21919,19 +22610,19 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *             dtype, roffset = fields[fieldname]
  */
 
-#line 422 "root_numpy/src/tree.pyx"
-          __pyx_t_5 = __Pyx_GetItemInt(__pyx_v_fieldnames, __pyx_v_icol, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 1); if (unlikely(__pyx_t_5 == NULL)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 422; __pyx_clineno = __LINE__; goto __pyx_L6_error;};
+#line 440 "root_numpy/src/tree.pyx"
+          __pyx_t_5 = __Pyx_GetItemInt(__pyx_v_fieldnames, __pyx_v_icol, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 1); if (unlikely(__pyx_t_5 == NULL)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L6_error;};
 
-#line 422 "root_numpy/src/tree.pyx"
+#line 440 "root_numpy/src/tree.pyx"
           __Pyx_GOTREF(__pyx_t_5);
 
-#line 422 "root_numpy/src/tree.pyx"
+#line 440 "root_numpy/src/tree.pyx"
           __Pyx_XDECREF_SET(__pyx_v_fieldname, __pyx_t_5);
 
-#line 422 "root_numpy/src/tree.pyx"
+#line 440 "root_numpy/src/tree.pyx"
           __pyx_t_5 = 0;
 
-          /* "root_numpy/src/tree.pyx":424
+          /* "root_numpy/src/tree.pyx":442
  *             fieldname = fieldnames[icol]
  *             # roffset is an offset of particular field in each record
  *             dtype, roffset = fields[fieldname]             # <<<<<<<<<<<<<<
@@ -21939,178 +22630,178 @@ static TTree *__pyx_f_13_librootnumpy_array2tree(PyArrayObject *__pyx_v_arr, str
  *             if cvt != NULL:
  */
 
-#line 424 "root_numpy/src/tree.pyx"
-          __pyx_t_5 = PyObject_GetItem(__pyx_v_fields, __pyx_v_fieldname); if (unlikely(__pyx_t_5 == NULL)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;};
+#line 442 "root_numpy/src/tree.pyx"
+          __pyx_t_5 = PyObject_GetItem(__pyx_v_fields, __pyx_v_fieldname); if (unlikely(__pyx_t_5 == NULL)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;};
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           __Pyx_GOTREF(__pyx_t_5);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           if ((likely(PyTuple_CheckExact(__pyx_t_5))) || (PyList_CheckExact(__pyx_t_5))) {
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             PyObject* sequence = __pyx_t_5;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             #if CYTHON_COMPILING_IN_CPYTHON
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             Py_ssize_t size = Py_SIZE(sequence);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             #else
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             Py_ssize_t size = PySequence_Size(sequence);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             #endif
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             if (unlikely(size != 2)) {
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
               if (size > 2) __Pyx_RaiseTooManyValuesError(2);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
               else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
 
-#line 424 "root_numpy/src/tree.pyx"
-              {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 442 "root_numpy/src/tree.pyx"
+              {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             }
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             #if CYTHON_COMPILING_IN_CPYTHON
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             if (likely(PyTuple_CheckExact(sequence))) {
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
               __pyx_t_6 = PyTuple_GET_ITEM(sequence, 0); 
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
               __pyx_t_9 = PyTuple_GET_ITEM(sequence, 1); 
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             } else {
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
               __pyx_t_6 = PyList_GET_ITEM(sequence, 0); 
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
               __pyx_t_9 = PyList_GET_ITEM(sequence, 1); 
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             }
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_INCREF(__pyx_t_6);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_INCREF(__pyx_t_9);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             #else
 
-#line 424 "root_numpy/src/tree.pyx"
-            __pyx_t_6 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 442 "root_numpy/src/tree.pyx"
+            __pyx_t_6 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_6);
 
-#line 424 "root_numpy/src/tree.pyx"
-            __pyx_t_9 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 442 "root_numpy/src/tree.pyx"
+            __pyx_t_9 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_9);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             #endif
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           } else {
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             Py_ssize_t index = -1;
 
-#line 424 "root_numpy/src/tree.pyx"
-            __pyx_t_10 = PyObject_GetIter(__pyx_t_5); if (unlikely(!__pyx_t_10)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 442 "root_numpy/src/tree.pyx"
+            __pyx_t_10 = PyObject_GetIter(__pyx_t_5); if (unlikely(!__pyx_t_10)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_10);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __pyx_t_11 = Py_TYPE(__pyx_t_10)->tp_iternext;
             index = 0; __pyx_t_6 = __pyx_t_11(__pyx_t_10); if (unlikely(!__pyx_t_6)) 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
 goto __pyx_L17_unpacking_failed;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_6);
             index = 1; __pyx_t_9 = __pyx_t_11(__pyx_t_10); if (unlikely(!__pyx_t_9)) 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
 goto __pyx_L17_unpacking_failed;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_9);
 
-#line 424 "root_numpy/src/tree.pyx"
-            if (__Pyx_IternextUnpackEndCheck(__pyx_t_11(__pyx_t_10), 2) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 442 "root_numpy/src/tree.pyx"
+            if (__Pyx_IternextUnpackEndCheck(__pyx_t_11(__pyx_t_10), 2) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __pyx_t_11 = NULL;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             goto __pyx_L18_unpacking_done;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __pyx_L17_unpacking_failed:;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __pyx_t_11 = NULL;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
 
-#line 424 "root_numpy/src/tree.pyx"
-            {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 442 "root_numpy/src/tree.pyx"
+            {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
             __pyx_L18_unpacking_done:;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           }
 
-#line 424 "root_numpy/src/tree.pyx"
-          __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_9); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 442 "root_numpy/src/tree.pyx"
+          __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_9); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_6);
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           __pyx_t_6 = 0;
 
-#line 424 "root_numpy/src/tree.pyx"
+#line 442 "root_numpy/src/tree.pyx"
           __pyx_v_roffset = __pyx_t_12;
 
-          /* "root_numpy/src/tree.pyx":425
+          /* "root_numpy/src/tree.pyx":443
  *             # roffset is an offset of particular field in each record
  *             dtype, roffset = fields[fieldname]
  *             cvt = find_np2root_converter(tree, fieldname, dtype)             # <<<<<<<<<<<<<<
@@ -22118,10 +22809,10 @@ goto __pyx_L17_unpacking_failed;
  *                 roffsetarray.push_back(roffset)
  */
 
-#line 425 "root_numpy/src/tree.pyx"
+#line 443 "root_numpy/src/tree.pyx"
           __pyx_v_cvt = __pyx_f_13_librootnumpy_find_np2root_converter(__pyx_v_tree, __pyx_v_fieldname, __pyx_v_dtype);
 
-          /* "root_numpy/src/tree.pyx":426
+          /* "root_numpy/src/tree.pyx":444
  *             dtype, roffset = fields[fieldname]
  *             cvt = find_np2root_converter(tree, fieldname, dtype)
  *             if cvt != NULL:             # <<<<<<<<<<<<<<
@@ -22129,13 +22820,13 @@ goto __pyx_L17_unpacking_failed;
  *                 converters.push_back(cvt)
  */
 
-#line 426 "root_numpy/src/tree.pyx"
+#line 444 "root_numpy/src/tree.pyx"
           __pyx_t_4 = ((__pyx_v_cvt != NULL) != 0);
 
-#line 426 "root_numpy/src/tree.pyx"
+#line 444 "root_numpy/src/tree.pyx"
           if (__pyx_t_4) {
 
-            /* "root_numpy/src/tree.pyx":427
+            /* "root_numpy/src/tree.pyx":445
  *             cvt = find_np2root_converter(tree, fieldname, dtype)
  *             if cvt != NULL:
  *                 roffsetarray.push_back(roffset)             # <<<<<<<<<<<<<<
@@ -22143,10 +22834,10 @@ goto __pyx_L17_unpacking_failed;
  *             else:
  */
 
-#line 427 "root_numpy/src/tree.pyx"
+#line 445 "root_numpy/src/tree.pyx"
             __pyx_v_roffsetarray.push_back(__pyx_v_roffset);
 
-            /* "root_numpy/src/tree.pyx":428
+            /* "root_numpy/src/tree.pyx":446
  *             if cvt != NULL:
  *                 roffsetarray.push_back(roffset)
  *                 converters.push_back(cvt)             # <<<<<<<<<<<<<<
@@ -22154,19 +22845,19 @@ goto __pyx_L17_unpacking_failed;
  *                 warnings.warn("converter for {!r} is not "
  */
 
-#line 428 "root_numpy/src/tree.pyx"
+#line 446 "root_numpy/src/tree.pyx"
             __pyx_v_converters.push_back(__pyx_v_cvt);
 
-#line 428 "root_numpy/src/tree.pyx"
+#line 446 "root_numpy/src/tree.pyx"
             goto __pyx_L19;
 
-#line 428 "root_numpy/src/tree.pyx"
+#line 446 "root_numpy/src/tree.pyx"
           }
 
-#line 428 "root_numpy/src/tree.pyx"
+#line 446 "root_numpy/src/tree.pyx"
           /*else*/ {
 
-            /* "root_numpy/src/tree.pyx":430
+            /* "root_numpy/src/tree.pyx":448
  *                 converters.push_back(cvt)
  *             else:
  *                 warnings.warn("converter for {!r} is not "             # <<<<<<<<<<<<<<
@@ -22174,22 +22865,22 @@ goto __pyx_L17_unpacking_failed;
  * 
  */
 
-#line 430 "root_numpy/src/tree.pyx"
-            __pyx_t_9 = __Pyx_GetModuleGlobalName(__pyx_n_s_warnings); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 430; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 448 "root_numpy/src/tree.pyx"
+            __pyx_t_9 = __Pyx_GetModuleGlobalName(__pyx_n_s_warnings); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 448; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 430 "root_numpy/src/tree.pyx"
+#line 448 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_9);
 
-#line 430 "root_numpy/src/tree.pyx"
-            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_9, __pyx_n_s_warn); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 430; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 448 "root_numpy/src/tree.pyx"
+            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_9, __pyx_n_s_warn); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 448; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 430 "root_numpy/src/tree.pyx"
+#line 448 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_6);
 
-#line 430 "root_numpy/src/tree.pyx"
+#line 448 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
 
-            /* "root_numpy/src/tree.pyx":431
+            /* "root_numpy/src/tree.pyx":449
  *             else:
  *                 warnings.warn("converter for {!r} is not "
  *                               "implemented (skipping)".format(dtype))             # <<<<<<<<<<<<<<
@@ -22197,178 +22888,178 @@ goto __pyx_L17_unpacking_failed;
  *         # Fill the data
  */
 
-#line 431 "root_numpy/src/tree.pyx"
-            __pyx_t_10 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_converter_for_r_is_not_implement, __pyx_n_s_format); if (unlikely(!__pyx_t_10)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 431; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 449 "root_numpy/src/tree.pyx"
+            __pyx_t_10 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_converter_for_r_is_not_implement, __pyx_n_s_format); if (unlikely(!__pyx_t_10)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 449; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             __Pyx_GOTREF(__pyx_t_10);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             __pyx_t_13 = NULL;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_10))) {
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __pyx_t_13 = PyMethod_GET_SELF(__pyx_t_10);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               if (likely(__pyx_t_13)) {
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_10);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 __Pyx_INCREF(__pyx_t_13);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 __Pyx_INCREF(function);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 __Pyx_DECREF_SET(__pyx_t_10, function);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               }
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             }
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             if (!__pyx_t_13) {
 
-#line 431 "root_numpy/src/tree.pyx"
-              __pyx_t_9 = __Pyx_PyObject_CallOneArg(__pyx_t_10, __pyx_v_dtype); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 431; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 449 "root_numpy/src/tree.pyx"
+              __pyx_t_9 = __Pyx_PyObject_CallOneArg(__pyx_t_10, __pyx_v_dtype); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 449; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GOTREF(__pyx_t_9);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             } else {
 
-#line 431 "root_numpy/src/tree.pyx"
-              __pyx_t_14 = PyTuple_New(1+1); if (unlikely(!__pyx_t_14)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 431; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 449 "root_numpy/src/tree.pyx"
+              __pyx_t_14 = PyTuple_New(1+1); if (unlikely(!__pyx_t_14)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 449; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GOTREF(__pyx_t_14);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               PyTuple_SET_ITEM(__pyx_t_14, 0, __pyx_t_13); __Pyx_GIVEREF(__pyx_t_13); __pyx_t_13 = NULL;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_INCREF(__pyx_v_dtype);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               PyTuple_SET_ITEM(__pyx_t_14, 0+1, __pyx_v_dtype);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GIVEREF(__pyx_v_dtype);
 
-#line 431 "root_numpy/src/tree.pyx"
-              __pyx_t_9 = __Pyx_PyObject_Call(__pyx_t_10, __pyx_t_14, NULL); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 431; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 449 "root_numpy/src/tree.pyx"
+              __pyx_t_9 = __Pyx_PyObject_Call(__pyx_t_10, __pyx_t_14, NULL); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 449; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GOTREF(__pyx_t_9);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             }
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             __pyx_t_10 = NULL;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_6))) {
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __pyx_t_10 = PyMethod_GET_SELF(__pyx_t_6);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               if (likely(__pyx_t_10)) {
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_6);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 __Pyx_INCREF(__pyx_t_10);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 __Pyx_INCREF(function);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
                 __Pyx_DECREF_SET(__pyx_t_6, function);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               }
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             }
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             if (!__pyx_t_10) {
 
-#line 431 "root_numpy/src/tree.pyx"
-              __pyx_t_5 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_t_9); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 430; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 449 "root_numpy/src/tree.pyx"
+              __pyx_t_5 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_t_9); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 448; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GOTREF(__pyx_t_5);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             } else {
 
-#line 431 "root_numpy/src/tree.pyx"
-              __pyx_t_14 = PyTuple_New(1+1); if (unlikely(!__pyx_t_14)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 430; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 449 "root_numpy/src/tree.pyx"
+              __pyx_t_14 = PyTuple_New(1+1); if (unlikely(!__pyx_t_14)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 448; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GOTREF(__pyx_t_14);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               PyTuple_SET_ITEM(__pyx_t_14, 0, __pyx_t_10); __Pyx_GIVEREF(__pyx_t_10); __pyx_t_10 = NULL;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               PyTuple_SET_ITEM(__pyx_t_14, 0+1, __pyx_t_9);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GIVEREF(__pyx_t_9);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __pyx_t_9 = 0;
 
-#line 431 "root_numpy/src/tree.pyx"
-              __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_14, NULL); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 430; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
+#line 449 "root_numpy/src/tree.pyx"
+              __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_14, NULL); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 448; __pyx_clineno = __LINE__; goto __pyx_L6_error;}
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_GOTREF(__pyx_t_5);
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
               __Pyx_DECREF(__pyx_t_14); __pyx_t_14 = 0;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             }
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
             __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
           }
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
           __pyx_L19:;
 
-#line 431 "root_numpy/src/tree.pyx"
+#line 449 "root_numpy/src/tree.pyx"
         }
 
-        /* "root_numpy/src/tree.pyx":434
+        /* "root_numpy/src/tree.pyx":452
  * 
  *         # Fill the data
  *         num_cols = converters.size()             # <<<<<<<<<<<<<<
@@ -22376,10 +23067,10 @@ goto __pyx_L17_unpacking_failed;
  *             thisrow = np.PyArray_GETPTR1(arr, idata)
  */
 
-#line 434 "root_numpy/src/tree.pyx"
+#line 452 "root_numpy/src/tree.pyx"
         __pyx_v_num_cols = __pyx_v_converters.size();
 
-        /* "root_numpy/src/tree.pyx":435
+        /* "root_numpy/src/tree.pyx":453
  *         # Fill the data
  *         num_cols = converters.size()
  *         for idata in range(arr_len):             # <<<<<<<<<<<<<<
@@ -22387,16 +23078,16 @@ goto __pyx_L17_unpacking_failed;
  *             for icol in range(num_cols):
  */
 
-#line 435 "root_numpy/src/tree.pyx"
+#line 453 "root_numpy/src/tree.pyx"
         __pyx_t_15 = __pyx_v_arr_len;
 
-#line 435 "root_numpy/src/tree.pyx"
+#line 453 "root_numpy/src/tree.pyx"
         for (__pyx_t_16 = 0; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
 
-#line 435 "root_numpy/src/tree.pyx"
+#line 453 "root_numpy/src/tree.pyx"
           __pyx_v_idata = __pyx_t_16;
 
-          /* "root_numpy/src/tree.pyx":436
+          /* "root_numpy/src/tree.pyx":454
  *         num_cols = converters.size()
  *         for idata in range(arr_len):
  *             thisrow = np.PyArray_GETPTR1(arr, idata)             # <<<<<<<<<<<<<<
@@ -22404,10 +23095,10 @@ goto __pyx_L17_unpacking_failed;
  *                 roffset = roffsetarray[icol]
  */
 
-#line 436 "root_numpy/src/tree.pyx"
+#line 454 "root_numpy/src/tree.pyx"
           __pyx_v_thisrow = PyArray_GETPTR1(__pyx_v_arr, __pyx_v_idata);
 
-          /* "root_numpy/src/tree.pyx":437
+          /* "root_numpy/src/tree.pyx":455
  *         for idata in range(arr_len):
  *             thisrow = np.PyArray_GETPTR1(arr, idata)
  *             for icol in range(num_cols):             # <<<<<<<<<<<<<<
@@ -22415,16 +23106,16 @@ goto __pyx_L17_unpacking_failed;
  *                 source = shift(thisrow, roffset)
  */
 
-#line 437 "root_numpy/src/tree.pyx"
+#line 455 "root_numpy/src/tree.pyx"
           __pyx_t_8 = __pyx_v_num_cols;
 
-#line 437 "root_numpy/src/tree.pyx"
+#line 455 "root_numpy/src/tree.pyx"
           for (__pyx_t_17 = 0; __pyx_t_17 < __pyx_t_8; __pyx_t_17+=1) {
 
-#line 437 "root_numpy/src/tree.pyx"
+#line 455 "root_numpy/src/tree.pyx"
             __pyx_v_icol = __pyx_t_17;
 
-            /* "root_numpy/src/tree.pyx":438
+            /* "root_numpy/src/tree.pyx":456
  *             thisrow = np.PyArray_GETPTR1(arr, idata)
  *             for icol in range(num_cols):
  *                 roffset = roffsetarray[icol]             # <<<<<<<<<<<<<<
@@ -22432,10 +23123,10 @@ goto __pyx_L17_unpacking_failed;
  *                 converters[icol].fill_from(source)
  */
 
-#line 438 "root_numpy/src/tree.pyx"
+#line 456 "root_numpy/src/tree.pyx"
             __pyx_v_roffset = (__pyx_v_roffsetarray[__pyx_v_icol]);
 
-            /* "root_numpy/src/tree.pyx":439
+            /* "root_numpy/src/tree.pyx":457
  *             for icol in range(num_cols):
  *                 roffset = roffsetarray[icol]
  *                 source = shift(thisrow, roffset)             # <<<<<<<<<<<<<<
@@ -22443,10 +23134,10 @@ goto __pyx_L17_unpacking_failed;
  * 
  */
 
-#line 439 "root_numpy/src/tree.pyx"
+#line 457 "root_numpy/src/tree.pyx"
             __pyx_v_source = shift(__pyx_v_thisrow, __pyx_v_roffset);
 
-            /* "root_numpy/src/tree.pyx":440
+            /* "root_numpy/src/tree.pyx":458
  *                 roffset = roffsetarray[icol]
  *                 source = shift(thisrow, roffset)
  *                 converters[icol].fill_from(source)             # <<<<<<<<<<<<<<
@@ -22454,16 +23145,16 @@ goto __pyx_L17_unpacking_failed;
  *         # Need to update the number of entries in the tree to match
  */
 
-#line 440 "root_numpy/src/tree.pyx"
+#line 458 "root_numpy/src/tree.pyx"
             (__pyx_v_converters[__pyx_v_icol])->fill_from(__pyx_v_source);
 
-#line 440 "root_numpy/src/tree.pyx"
+#line 458 "root_numpy/src/tree.pyx"
           }
 
-#line 440 "root_numpy/src/tree.pyx"
+#line 458 "root_numpy/src/tree.pyx"
         }
 
-        /* "root_numpy/src/tree.pyx":444
+        /* "root_numpy/src/tree.pyx":462
  *         # Need to update the number of entries in the tree to match
  *         # the number in the branches since each branch is filled separately.
  *         tree.SetEntries(-1)             # <<<<<<<<<<<<<<
@@ -22471,46 +23162,46 @@ goto __pyx_L17_unpacking_failed;
  *     except:
  */
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
         __pyx_v_tree->SetEntries(-1);
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       }
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       goto __pyx_L13_try_end;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __pyx_L6_error:;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_13); __pyx_t_13 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_10); __pyx_t_10 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-#line 444 "root_numpy/src/tree.pyx"
+#line 462 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-      /* "root_numpy/src/tree.pyx":446
+      /* "root_numpy/src/tree.pyx":464
  *         tree.SetEntries(-1)
  * 
  *     except:             # <<<<<<<<<<<<<<
@@ -22518,25 +23209,25 @@ goto __pyx_L17_unpacking_failed;
  * 
  */
 
-#line 446 "root_numpy/src/tree.pyx"
+#line 464 "root_numpy/src/tree.pyx"
       /*except:*/ {
 
-#line 446 "root_numpy/src/tree.pyx"
+#line 464 "root_numpy/src/tree.pyx"
         __Pyx_AddTraceback("_librootnumpy.array2tree", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 446 "root_numpy/src/tree.pyx"
-        if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_14) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 446; __pyx_clineno = __LINE__; goto __pyx_L8_except_error;}
+#line 464 "root_numpy/src/tree.pyx"
+        if (__Pyx_GetException(&__pyx_t_5, &__pyx_t_6, &__pyx_t_14) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 464; __pyx_clineno = __LINE__; goto __pyx_L8_except_error;}
 
-#line 446 "root_numpy/src/tree.pyx"
+#line 464 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_5);
 
-#line 446 "root_numpy/src/tree.pyx"
+#line 464 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_6);
 
-#line 446 "root_numpy/src/tree.pyx"
+#line 464 "root_numpy/src/tree.pyx"
         __Pyx_GOTREF(__pyx_t_14);
 
-        /* "root_numpy/src/tree.pyx":447
+        /* "root_numpy/src/tree.pyx":465
  * 
  *     except:
  *         raise             # <<<<<<<<<<<<<<
@@ -22544,55 +23235,55 @@ goto __pyx_L17_unpacking_failed;
  *     finally:
  */
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
         __Pyx_GIVEREF(__pyx_t_5);
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
         __Pyx_GIVEREF(__pyx_t_6);
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
         __Pyx_XGIVEREF(__pyx_t_14);
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
         __Pyx_ErrRestore(__pyx_t_5, __pyx_t_6, __pyx_t_14);
         __pyx_t_5 = 0; __pyx_t_6 = 0; __pyx_t_14 = 0; 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
 
 
-#line 447 "root_numpy/src/tree.pyx"
-        {__pyx_filename = __pyx_f[2]; __pyx_lineno = 447; __pyx_clineno = __LINE__; goto __pyx_L8_except_error;}
+#line 465 "root_numpy/src/tree.pyx"
+        {__pyx_filename = __pyx_f[2]; __pyx_lineno = 465; __pyx_clineno = __LINE__; goto __pyx_L8_except_error;}
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       }
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       __pyx_L8_except_error:;
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       __Pyx_XGIVEREF(__pyx_t_1);
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       __Pyx_XGIVEREF(__pyx_t_2);
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       __Pyx_XGIVEREF(__pyx_t_3);
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       __Pyx_ExceptionReset(__pyx_t_1, __pyx_t_2, __pyx_t_3);
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       goto __pyx_L4_error;
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
       __pyx_L13_try_end:;
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
     }
 
-#line 447 "root_numpy/src/tree.pyx"
+#line 465 "root_numpy/src/tree.pyx"
   }
 
-  /* "root_numpy/src/tree.pyx":450
+  /* "root_numpy/src/tree.pyx":468
  * 
  *     finally:
  *         for icol in range(converters.size()):             # <<<<<<<<<<<<<<
@@ -22600,22 +23291,22 @@ goto __pyx_L17_unpacking_failed;
  *         # TODO: clean up tree
  */
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
   /*finally:*/ {
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
     /*normal exit:*/{
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
       __pyx_t_18 = __pyx_v_converters.size();
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
       for (__pyx_t_8 = 0; __pyx_t_8 < __pyx_t_18; __pyx_t_8+=1) {
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
         __pyx_v_icol = __pyx_t_8;
 
-        /* "root_numpy/src/tree.pyx":451
+        /* "root_numpy/src/tree.pyx":469
  *     finally:
  *         for icol in range(converters.size()):
  *             del converters[icol]             # <<<<<<<<<<<<<<
@@ -22623,76 +23314,76 @@ goto __pyx_L17_unpacking_failed;
  * 
  */
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
         delete (__pyx_v_converters[__pyx_v_icol]);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       }
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       goto __pyx_L5;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
     }
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
     /*exception exit:*/{
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __pyx_L4_error:;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __pyx_t_3 = 0; __pyx_t_2 = 0; __pyx_t_1 = 0; __pyx_t_21 = 0; __pyx_t_22 = 0; __pyx_t_23 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_13); __pyx_t_13 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_10); __pyx_t_10 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XDECREF(__pyx_t_14); __pyx_t_14 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       if (PY_MAJOR_VERSION >= 3) __Pyx_ExceptionSwap(&__pyx_t_21, &__pyx_t_22, &__pyx_t_23);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       if ((PY_MAJOR_VERSION < 3) || unlikely(__Pyx_GetException(&__pyx_t_3, &__pyx_t_2, &__pyx_t_1) < 0)) __Pyx_ErrFetch(&__pyx_t_3, &__pyx_t_2, &__pyx_t_1);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_3);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_2);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_1);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_21);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_22);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGOTREF(__pyx_t_23);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __pyx_t_12 = __pyx_lineno; __pyx_t_19 = __pyx_clineno; __pyx_t_20 = __pyx_filename;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       {
 
-        /* "root_numpy/src/tree.pyx":450
+        /* "root_numpy/src/tree.pyx":468
  * 
  *     finally:
  *         for icol in range(converters.size()):             # <<<<<<<<<<<<<<
@@ -22700,16 +23391,16 @@ goto __pyx_L17_unpacking_failed;
  *         # TODO: clean up tree
  */
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
         __pyx_t_18 = __pyx_v_converters.size();
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
         for (__pyx_t_8 = 0; __pyx_t_8 < __pyx_t_18; __pyx_t_8+=1) {
 
-#line 450 "root_numpy/src/tree.pyx"
+#line 468 "root_numpy/src/tree.pyx"
           __pyx_v_icol = __pyx_t_8;
 
-          /* "root_numpy/src/tree.pyx":451
+          /* "root_numpy/src/tree.pyx":469
  *     finally:
  *         for icol in range(converters.size()):
  *             del converters[icol]             # <<<<<<<<<<<<<<
@@ -22717,64 +23408,64 @@ goto __pyx_L17_unpacking_failed;
  * 
  */
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
           delete (__pyx_v_converters[__pyx_v_icol]);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
         }
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       }
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       if (PY_MAJOR_VERSION >= 3) {
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
         __Pyx_XGIVEREF(__pyx_t_21);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
         __Pyx_XGIVEREF(__pyx_t_22);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
         __Pyx_XGIVEREF(__pyx_t_23);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
         __Pyx_ExceptionReset(__pyx_t_21, __pyx_t_22, __pyx_t_23);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       }
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGIVEREF(__pyx_t_3);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGIVEREF(__pyx_t_2);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_XGIVEREF(__pyx_t_1);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __Pyx_ErrRestore(__pyx_t_3, __pyx_t_2, __pyx_t_1);
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __pyx_t_3 = 0; __pyx_t_2 = 0; __pyx_t_1 = 0; __pyx_t_21 = 0; __pyx_t_22 = 0; __pyx_t_23 = 0;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       __pyx_lineno = __pyx_t_12; __pyx_clineno = __pyx_t_19; __pyx_filename = __pyx_t_20;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
       goto __pyx_L1_error;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
     }
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
     __pyx_L5:;
 
-#line 451 "root_numpy/src/tree.pyx"
+#line 469 "root_numpy/src/tree.pyx"
   }
 
-  /* "root_numpy/src/tree.pyx":454
+  /* "root_numpy/src/tree.pyx":472
  *         # TODO: clean up tree
  * 
  *     return tree             # <<<<<<<<<<<<<<
@@ -22782,13 +23473,13 @@ goto __pyx_L17_unpacking_failed;
  * 
  */
 
-#line 454 "root_numpy/src/tree.pyx"
+#line 472 "root_numpy/src/tree.pyx"
   __pyx_r = __pyx_v_tree;
 
-#line 454 "root_numpy/src/tree.pyx"
+#line 472 "root_numpy/src/tree.pyx"
   goto __pyx_L0;
 
-  /* "root_numpy/src/tree.pyx":401
+  /* "root_numpy/src/tree.pyx":419
  * 
  * 
  * cdef TTree* array2tree(np.ndarray arr, string name='tree', TTree* tree=NULL) except *:             # <<<<<<<<<<<<<<
@@ -22796,64 +23487,64 @@ goto __pyx_L17_unpacking_failed;
  *     cdef NP2ROOTConverter* cvt
  */
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   /* function exit code */
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __pyx_L1_error:;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_5);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_6);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_9);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_10);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_13);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_14);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.array2tree", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __pyx_r = 0;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __pyx_L0:;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_v_fieldnames);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_v_fields);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_v_fieldname);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_v_dtype);
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   return __pyx_r;
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
 }
 
-/* "root_numpy/src/tree.pyx":457
+/* "root_numpy/src/tree.pyx":475
  * 
  * 
  * def array2tree_toCObj(arr, name='tree', tree=None):             # <<<<<<<<<<<<<<
@@ -22861,238 +23552,238 @@ goto __pyx_L17_unpacking_failed;
  *     cdef TTree* outtree = NULL
  */
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 /* Python wrapper */
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pw_13_librootnumpy_13array2tree_toCObj(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
 static PyMethodDef __pyx_mdef_13_librootnumpy_13array2tree_toCObj = 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 {"array2tree_toCObj", (PyCFunction)__pyx_pw_13_librootnumpy_13array2tree_toCObj, METH_VARARGS|METH_KEYWORDS, 0};
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pw_13_librootnumpy_13array2tree_toCObj(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_arr = 0
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_name = 0
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_tree = 0
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 ;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   PyObject *__pyx_r = 0;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyDeclarations
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_RefNannySetupContext("array2tree_toCObj (wrapper)", 0);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   {
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_arr,&__pyx_n_s_name,&__pyx_n_s_tree,0};
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     PyObject* values[3] = {0,0,0};
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     values[1] = ((PyObject *)__pyx_n_s_tree);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     values[2] = ((PyObject *)Py_None);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     if (unlikely(__pyx_kwds)) {
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       Py_ssize_t kw_args;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       const Py_ssize_t pos_args = PyTuple_GET_SIZE(__pyx_args);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       switch (pos_args) {
         case  3: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
         case  2: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
         case  1: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         case  0: break;
         default: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       kw_args = PyDict_Size(__pyx_kwds);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       switch (pos_args) {
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         case  0:
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         if (likely((values[0] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_arr)) != 0)) kw_args--;
         else 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         case  1:
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         if (kw_args > 0) {
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
           PyObject* value = PyDict_GetItem(__pyx_kwds, __pyx_n_s_name);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
           if (value) { values[1] = value; kw_args--; }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         case  2:
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         if (kw_args > 0) {
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
           PyObject* value = PyDict_GetItem(__pyx_kwds, __pyx_n_s_tree);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
           if (value) { values[2] = value; kw_args--; }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       if (unlikely(kw_args > 0)) {
 
-#line 457 "root_numpy/src/tree.pyx"
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "array2tree_toCObj") < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 475 "root_numpy/src/tree.pyx"
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "array2tree_toCObj") < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     } else {
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       switch (PyTuple_GET_SIZE(__pyx_args)) {
         case  3: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
         case  2: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
         case  1: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
         break;
         default: 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
       }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     __pyx_v_arr = values[0];
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     __pyx_v_name = values[1];
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
     __pyx_v_tree = values[2];
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   goto __pyx_L4_argument_unpacking_done;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __pyx_L5_argtuple_error:;
   __Pyx_RaiseArgtupleInvalid("array2tree_toCObj", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); 
-#line 457 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 475 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __pyx_L3_error:;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.array2tree_toCObj", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   return NULL;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __pyx_L4_argument_unpacking_done:;
   __pyx_r = 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 __pyx_pf_13_librootnumpy_12array2tree_toCObj(__pyx_self, __pyx_v_arr, __pyx_v_name, __pyx_v_tree);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   /* function exit code */
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   return __pyx_r;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 }
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_arr, PyObject *__pyx_v_name, PyObject *__pyx_v_tree) {
   TTree *__pyx_v_intree
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 ;
   TTree *__pyx_v_outtree
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 ;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
@@ -23106,10 +23797,10 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_RefNannySetupContext("array2tree_toCObj", 0);
 
-  /* "root_numpy/src/tree.pyx":458
+  /* "root_numpy/src/tree.pyx":476
  * 
  * def array2tree_toCObj(arr, name='tree', tree=None):
  *     cdef TTree* intree = NULL             # <<<<<<<<<<<<<<
@@ -23117,10 +23808,10 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  *     if tree is not None:
  */
 
-#line 458 "root_numpy/src/tree.pyx"
+#line 476 "root_numpy/src/tree.pyx"
   __pyx_v_intree = NULL;
 
-  /* "root_numpy/src/tree.pyx":459
+  /* "root_numpy/src/tree.pyx":477
  * def array2tree_toCObj(arr, name='tree', tree=None):
  *     cdef TTree* intree = NULL
  *     cdef TTree* outtree = NULL             # <<<<<<<<<<<<<<
@@ -23128,10 +23819,10 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  *         intree = <TTree*> PyCObject_AsVoidPtr(tree)
  */
 
-#line 459 "root_numpy/src/tree.pyx"
+#line 477 "root_numpy/src/tree.pyx"
   __pyx_v_outtree = NULL;
 
-  /* "root_numpy/src/tree.pyx":460
+  /* "root_numpy/src/tree.pyx":478
  *     cdef TTree* intree = NULL
  *     cdef TTree* outtree = NULL
  *     if tree is not None:             # <<<<<<<<<<<<<<
@@ -23139,16 +23830,16 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  *     outtree = array2tree(arr, name=name, tree=intree)
  */
 
-#line 460 "root_numpy/src/tree.pyx"
+#line 478 "root_numpy/src/tree.pyx"
   __pyx_t_1 = (__pyx_v_tree != Py_None);
 
-#line 460 "root_numpy/src/tree.pyx"
+#line 478 "root_numpy/src/tree.pyx"
   __pyx_t_2 = (__pyx_t_1 != 0);
 
-#line 460 "root_numpy/src/tree.pyx"
+#line 478 "root_numpy/src/tree.pyx"
   if (__pyx_t_2) {
 
-    /* "root_numpy/src/tree.pyx":461
+    /* "root_numpy/src/tree.pyx":479
  *     cdef TTree* outtree = NULL
  *     if tree is not None:
  *         intree = <TTree*> PyCObject_AsVoidPtr(tree)             # <<<<<<<<<<<<<<
@@ -23156,22 +23847,22 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  *     return PyCObject_FromVoidPtr(outtree, NULL)
  */
 
-#line 461 "root_numpy/src/tree.pyx"
-    __pyx_t_3 = PyCObject_AsVoidPtr(__pyx_v_tree); if (unlikely(__pyx_t_3 == NULL && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 479 "root_numpy/src/tree.pyx"
+    __pyx_t_3 = PyCObject_AsVoidPtr(__pyx_v_tree); if (unlikely(__pyx_t_3 == NULL && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 479; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 461 "root_numpy/src/tree.pyx"
+#line 479 "root_numpy/src/tree.pyx"
     __pyx_v_intree = ((TTree *)__pyx_t_3);
 
-#line 461 "root_numpy/src/tree.pyx"
+#line 479 "root_numpy/src/tree.pyx"
     goto __pyx_L3;
 
-#line 461 "root_numpy/src/tree.pyx"
+#line 479 "root_numpy/src/tree.pyx"
   }
 
-#line 461 "root_numpy/src/tree.pyx"
+#line 479 "root_numpy/src/tree.pyx"
   __pyx_L3:;
 
-  /* "root_numpy/src/tree.pyx":462
+  /* "root_numpy/src/tree.pyx":480
  *     if tree is not None:
  *         intree = <TTree*> PyCObject_AsVoidPtr(tree)
  *     outtree = array2tree(arr, name=name, tree=intree)             # <<<<<<<<<<<<<<
@@ -23179,28 +23870,28 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  * 
  */
 
-#line 462 "root_numpy/src/tree.pyx"
-  if (!(likely(((__pyx_v_arr) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arr, __pyx_ptype_5numpy_ndarray))))) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 480 "root_numpy/src/tree.pyx"
+  if (!(likely(((__pyx_v_arr) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arr, __pyx_ptype_5numpy_ndarray))))) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 480; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 462 "root_numpy/src/tree.pyx"
-  __pyx_t_4 = __pyx_convert_string_from_py_std__string(__pyx_v_name); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 480 "root_numpy/src/tree.pyx"
+  __pyx_t_4 = __pyx_convert_string_from_py_std__string(__pyx_v_name); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 480; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 462 "root_numpy/src/tree.pyx"
+#line 480 "root_numpy/src/tree.pyx"
   __pyx_t_6.__pyx_n = 2;
 
-#line 462 "root_numpy/src/tree.pyx"
+#line 480 "root_numpy/src/tree.pyx"
   __pyx_t_6.name = __pyx_t_4;
 
-#line 462 "root_numpy/src/tree.pyx"
+#line 480 "root_numpy/src/tree.pyx"
   __pyx_t_6.tree = __pyx_v_intree;
 
-#line 462 "root_numpy/src/tree.pyx"
-  __pyx_t_5 = __pyx_f_13_librootnumpy_array2tree(((PyArrayObject *)__pyx_v_arr), &__pyx_t_6); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 480 "root_numpy/src/tree.pyx"
+  __pyx_t_5 = __pyx_f_13_librootnumpy_array2tree(((PyArrayObject *)__pyx_v_arr), &__pyx_t_6); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 480; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 462 "root_numpy/src/tree.pyx"
+#line 480 "root_numpy/src/tree.pyx"
   __pyx_v_outtree = __pyx_t_5;
 
-  /* "root_numpy/src/tree.pyx":463
+  /* "root_numpy/src/tree.pyx":481
  *         intree = <TTree*> PyCObject_AsVoidPtr(tree)
  *     outtree = array2tree(arr, name=name, tree=intree)
  *     return PyCObject_FromVoidPtr(outtree, NULL)             # <<<<<<<<<<<<<<
@@ -23208,25 +23899,25 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  * 
  */
 
-#line 463 "root_numpy/src/tree.pyx"
+#line 481 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_r);
 
-#line 463 "root_numpy/src/tree.pyx"
-  __pyx_t_7 = PyCObject_FromVoidPtr(__pyx_v_outtree, NULL); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 463; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 481 "root_numpy/src/tree.pyx"
+  __pyx_t_7 = PyCObject_FromVoidPtr(__pyx_v_outtree, NULL); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 481; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 463 "root_numpy/src/tree.pyx"
+#line 481 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_t_7);
 
-#line 463 "root_numpy/src/tree.pyx"
+#line 481 "root_numpy/src/tree.pyx"
   __pyx_r = __pyx_t_7;
 
-#line 463 "root_numpy/src/tree.pyx"
+#line 481 "root_numpy/src/tree.pyx"
   __pyx_t_7 = 0;
 
-#line 463 "root_numpy/src/tree.pyx"
+#line 481 "root_numpy/src/tree.pyx"
   goto __pyx_L0;
 
-  /* "root_numpy/src/tree.pyx":457
+  /* "root_numpy/src/tree.pyx":475
  * 
  * 
  * def array2tree_toCObj(arr, name='tree', tree=None):             # <<<<<<<<<<<<<<
@@ -23234,40 +23925,40 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  *     cdef TTree* outtree = NULL
  */
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   /* function exit code */
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __pyx_L1_error:;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_7);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.array2tree_toCObj", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __pyx_r = NULL;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __pyx_L0:;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   return __pyx_r;
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
 }
 
-/* "root_numpy/src/tree.pyx":466
+/* "root_numpy/src/tree.pyx":484
  * 
  * 
  * def array2root(arr, filename, treename='tree', mode='update'):             # <<<<<<<<<<<<<<
@@ -23275,265 +23966,265 @@ static PyObject *__pyx_pf_13_librootnumpy_12array2tree_toCObj(CYTHON_UNUSED PyOb
  *     if rfile == NULL:
  */
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 /* Python wrapper */
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pw_13_librootnumpy_15array2root(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
 static PyMethodDef __pyx_mdef_13_librootnumpy_15array2root = 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 {"array2root", (PyCFunction)__pyx_pw_13_librootnumpy_15array2root, METH_VARARGS|METH_KEYWORDS, 0};
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pw_13_librootnumpy_15array2root(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_arr = 0
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_filename = 0
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_treename = 0
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 ;
   PyObject *__pyx_v_mode = 0
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 ;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   PyObject *__pyx_r = 0;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyDeclarations
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_RefNannySetupContext("array2root (wrapper)", 0);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   {
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_arr,&__pyx_n_s_filename,&__pyx_n_s_treename,&__pyx_n_s_mode,0};
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     PyObject* values[4] = {0,0,0,0};
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     values[2] = ((PyObject *)__pyx_n_s_tree);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     values[3] = ((PyObject *)__pyx_n_s_update);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     if (unlikely(__pyx_kwds)) {
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       Py_ssize_t kw_args;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       const Py_ssize_t pos_args = PyTuple_GET_SIZE(__pyx_args);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       switch (pos_args) {
         case  4: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
         case  3: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
         case  2: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
         case  1: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         case  0: break;
         default: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       kw_args = PyDict_Size(__pyx_kwds);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       switch (pos_args) {
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         case  0:
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         if (likely((values[0] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_arr)) != 0)) kw_args--;
         else 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         case  1:
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_filename)) != 0)) kw_args--;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         else {
           __Pyx_RaiseArgtupleInvalid("array2root", 0, 2, 4, 1); 
-#line 466 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 484 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         case  2:
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         if (kw_args > 0) {
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
           PyObject* value = PyDict_GetItem(__pyx_kwds, __pyx_n_s_treename);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
           if (value) { values[2] = value; kw_args--; }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         case  3:
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         if (kw_args > 0) {
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
           PyObject* value = PyDict_GetItem(__pyx_kwds, __pyx_n_s_mode);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
           if (value) { values[3] = value; kw_args--; }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       if (unlikely(kw_args > 0)) {
 
-#line 466 "root_numpy/src/tree.pyx"
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "array2root") < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 484 "root_numpy/src/tree.pyx"
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "array2root") < 0)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     } else {
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       switch (PyTuple_GET_SIZE(__pyx_args)) {
         case  4: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
         case  3: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
         case  2: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
         break;
         default: 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 goto __pyx_L5_argtuple_error;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
       }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     __pyx_v_arr = values[0];
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     __pyx_v_filename = values[1];
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     __pyx_v_treename = values[2];
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
     __pyx_v_mode = values[3];
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   goto __pyx_L4_argument_unpacking_done;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __pyx_L5_argtuple_error:;
   __Pyx_RaiseArgtupleInvalid("array2root", 0, 2, 4, PyTuple_GET_SIZE(__pyx_args)); 
-#line 466 "root_numpy/src/tree.pyx"
-{__pyx_filename = __pyx_f[2]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+#line 484 "root_numpy/src/tree.pyx"
+{__pyx_filename = __pyx_f[2]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __pyx_L3_error:;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.array2root", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   return NULL;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __pyx_L4_argument_unpacking_done:;
   __pyx_r = 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 __pyx_pf_13_librootnumpy_14array2root(__pyx_self, __pyx_v_arr, __pyx_v_filename, __pyx_v_treename, __pyx_v_mode);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   /* function exit code */
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   return __pyx_r;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 }
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_arr, PyObject *__pyx_v_filename, PyObject *__pyx_v_treename, PyObject *__pyx_v_mode) {
   TFile *__pyx_v_rfile
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 ;
   TTree *__pyx_v_tree
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 ;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   const char *__pyx_t_1;
@@ -23550,10 +24241,10 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_RefNannySetupContext("array2root", 0);
 
-  /* "root_numpy/src/tree.pyx":467
+  /* "root_numpy/src/tree.pyx":485
  * 
  * def array2root(arr, filename, treename='tree', mode='update'):
  *     cdef TFile* rfile = Open(filename, mode)             # <<<<<<<<<<<<<<
@@ -23561,16 +24252,16 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *         raise IOError("cannot open file {0}".format(filename))
  */
 
-#line 467 "root_numpy/src/tree.pyx"
-  __pyx_t_1 = __Pyx_PyObject_AsString(__pyx_v_filename); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 467; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 485 "root_numpy/src/tree.pyx"
+  __pyx_t_1 = __Pyx_PyObject_AsString(__pyx_v_filename); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 485; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 467 "root_numpy/src/tree.pyx"
-  __pyx_t_2 = __Pyx_PyObject_AsString(__pyx_v_mode); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 467; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 485 "root_numpy/src/tree.pyx"
+  __pyx_t_2 = __Pyx_PyObject_AsString(__pyx_v_mode); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 485; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 467 "root_numpy/src/tree.pyx"
+#line 485 "root_numpy/src/tree.pyx"
   __pyx_v_rfile = TFile::Open(__pyx_t_1, __pyx_t_2);
 
-  /* "root_numpy/src/tree.pyx":468
+  /* "root_numpy/src/tree.pyx":486
  * def array2root(arr, filename, treename='tree', mode='update'):
  *     cdef TFile* rfile = Open(filename, mode)
  *     if rfile == NULL:             # <<<<<<<<<<<<<<
@@ -23578,13 +24269,13 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     if not rfile.IsWritable():
  */
 
-#line 468 "root_numpy/src/tree.pyx"
+#line 486 "root_numpy/src/tree.pyx"
   __pyx_t_3 = ((__pyx_v_rfile == NULL) != 0);
 
-#line 468 "root_numpy/src/tree.pyx"
+#line 486 "root_numpy/src/tree.pyx"
   if (__pyx_t_3) {
 
-    /* "root_numpy/src/tree.pyx":469
+    /* "root_numpy/src/tree.pyx":487
  *     cdef TFile* rfile = Open(filename, mode)
  *     if rfile == NULL:
  *         raise IOError("cannot open file {0}".format(filename))             # <<<<<<<<<<<<<<
@@ -23592,124 +24283,124 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *         raise IOError("file {0} is not writable".format(filename))
  */
 
-#line 469 "root_numpy/src/tree.pyx"
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_cannot_open_file_0, __pyx_n_s_format); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 469; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 487 "root_numpy/src/tree.pyx"
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_cannot_open_file_0, __pyx_n_s_format); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_GOTREF(__pyx_t_5);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __pyx_t_6 = NULL;
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_5))) {
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       __pyx_t_6 = PyMethod_GET_SELF(__pyx_t_5);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       if (likely(__pyx_t_6)) {
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
         PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_5);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
         __Pyx_INCREF(__pyx_t_6);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
         __Pyx_INCREF(function);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
         __Pyx_DECREF_SET(__pyx_t_5, function);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       }
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     }
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     if (!__pyx_t_6) {
 
-#line 469 "root_numpy/src/tree.pyx"
-      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_filename); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 469; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 487 "root_numpy/src/tree.pyx"
+      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_filename); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     } else {
 
-#line 469 "root_numpy/src/tree.pyx"
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 469; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 487 "root_numpy/src/tree.pyx"
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       __Pyx_GOTREF(__pyx_t_7);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __Pyx_GIVEREF(__pyx_t_6); __pyx_t_6 = NULL;
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       __Pyx_INCREF(__pyx_v_filename);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_v_filename);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       __Pyx_GIVEREF(__pyx_v_filename);
 
-#line 469 "root_numpy/src/tree.pyx"
-      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 469; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 487 "root_numpy/src/tree.pyx"
+      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     }
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 469 "root_numpy/src/tree.pyx"
-    __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 469; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 487 "root_numpy/src/tree.pyx"
+    __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_GOTREF(__pyx_t_5);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_GIVEREF(__pyx_t_4);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __pyx_t_4 = 0;
 
-#line 469 "root_numpy/src/tree.pyx"
-    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_5, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 469; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 487 "root_numpy/src/tree.pyx"
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_5, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_GOTREF(__pyx_t_4);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_Raise(__pyx_t_4, 0, 0, 0);
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 469 "root_numpy/src/tree.pyx"
-    {__pyx_filename = __pyx_f[2]; __pyx_lineno = 469; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 487 "root_numpy/src/tree.pyx"
+    {__pyx_filename = __pyx_f[2]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 469 "root_numpy/src/tree.pyx"
+#line 487 "root_numpy/src/tree.pyx"
   }
 
-  /* "root_numpy/src/tree.pyx":470
+  /* "root_numpy/src/tree.pyx":488
  *     if rfile == NULL:
  *         raise IOError("cannot open file {0}".format(filename))
  *     if not rfile.IsWritable():             # <<<<<<<<<<<<<<
@@ -23717,13 +24408,13 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     # If a tree with that name exists, we want to update it
  */
 
-#line 470 "root_numpy/src/tree.pyx"
+#line 488 "root_numpy/src/tree.pyx"
   __pyx_t_3 = ((!(__pyx_v_rfile->IsWritable() != 0)) != 0);
 
-#line 470 "root_numpy/src/tree.pyx"
+#line 488 "root_numpy/src/tree.pyx"
   if (__pyx_t_3) {
 
-    /* "root_numpy/src/tree.pyx":471
+    /* "root_numpy/src/tree.pyx":489
  *         raise IOError("cannot open file {0}".format(filename))
  *     if not rfile.IsWritable():
  *         raise IOError("file {0} is not writable".format(filename))             # <<<<<<<<<<<<<<
@@ -23731,124 +24422,124 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     cdef TTree* tree = <TTree*> rfile.Get(treename)
  */
 
-#line 471 "root_numpy/src/tree.pyx"
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_file_0_is_not_writable, __pyx_n_s_format); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 489 "root_numpy/src/tree.pyx"
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_kp_s_file_0_is_not_writable, __pyx_n_s_format); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_GOTREF(__pyx_t_5);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __pyx_t_7 = NULL;
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_5))) {
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       __pyx_t_7 = PyMethod_GET_SELF(__pyx_t_5);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       if (likely(__pyx_t_7)) {
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
         PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_5);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
         __Pyx_INCREF(__pyx_t_7);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
         __Pyx_INCREF(function);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
         __Pyx_DECREF_SET(__pyx_t_5, function);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       }
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     }
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     if (!__pyx_t_7) {
 
-#line 471 "root_numpy/src/tree.pyx"
-      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_filename); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 489 "root_numpy/src/tree.pyx"
+      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_filename); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     } else {
 
-#line 471 "root_numpy/src/tree.pyx"
-      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 489 "root_numpy/src/tree.pyx"
+      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       __Pyx_GOTREF(__pyx_t_6);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_7); __Pyx_GIVEREF(__pyx_t_7); __pyx_t_7 = NULL;
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       __Pyx_INCREF(__pyx_v_filename);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       PyTuple_SET_ITEM(__pyx_t_6, 0+1, __pyx_v_filename);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       __Pyx_GIVEREF(__pyx_v_filename);
 
-#line 471 "root_numpy/src/tree.pyx"
-      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_6, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 489 "root_numpy/src/tree.pyx"
+      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_6, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     }
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 471 "root_numpy/src/tree.pyx"
-    __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 489 "root_numpy/src/tree.pyx"
+    __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_GOTREF(__pyx_t_5);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_GIVEREF(__pyx_t_4);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __pyx_t_4 = 0;
 
-#line 471 "root_numpy/src/tree.pyx"
-    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_5, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 489 "root_numpy/src/tree.pyx"
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_IOError, __pyx_t_5, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_GOTREF(__pyx_t_4);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_Raise(__pyx_t_4, 0, 0, 0);
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 471 "root_numpy/src/tree.pyx"
-    {__pyx_filename = __pyx_f[2]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 489 "root_numpy/src/tree.pyx"
+    {__pyx_filename = __pyx_f[2]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 471 "root_numpy/src/tree.pyx"
+#line 489 "root_numpy/src/tree.pyx"
   }
 
-  /* "root_numpy/src/tree.pyx":473
+  /* "root_numpy/src/tree.pyx":491
  *         raise IOError("file {0} is not writable".format(filename))
  *     # If a tree with that name exists, we want to update it
  *     cdef TTree* tree = <TTree*> rfile.Get(treename)             # <<<<<<<<<<<<<<
@@ -23856,13 +24547,13 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     tree.Write(treename, 2) # TObject::kOverwrite
  */
 
-#line 473 "root_numpy/src/tree.pyx"
-  __pyx_t_2 = __Pyx_PyObject_AsString(__pyx_v_treename); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 473; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 491 "root_numpy/src/tree.pyx"
+  __pyx_t_2 = __Pyx_PyObject_AsString(__pyx_v_treename); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 491; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 473 "root_numpy/src/tree.pyx"
+#line 491 "root_numpy/src/tree.pyx"
   __pyx_v_tree = ((TTree *)__pyx_v_rfile->Get(__pyx_t_2));
 
-  /* "root_numpy/src/tree.pyx":474
+  /* "root_numpy/src/tree.pyx":492
  *     # If a tree with that name exists, we want to update it
  *     cdef TTree* tree = <TTree*> rfile.Get(treename)
  *     tree = array2tree(arr, name=treename, tree=tree)             # <<<<<<<<<<<<<<
@@ -23870,28 +24561,28 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     rfile.Close()
  */
 
-#line 474 "root_numpy/src/tree.pyx"
-  if (!(likely(((__pyx_v_arr) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arr, __pyx_ptype_5numpy_ndarray))))) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 474; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 492 "root_numpy/src/tree.pyx"
+  if (!(likely(((__pyx_v_arr) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_arr, __pyx_ptype_5numpy_ndarray))))) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 474 "root_numpy/src/tree.pyx"
-  __pyx_t_8 = __pyx_convert_string_from_py_std__string(__pyx_v_treename); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 474; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 492 "root_numpy/src/tree.pyx"
+  __pyx_t_8 = __pyx_convert_string_from_py_std__string(__pyx_v_treename); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 474 "root_numpy/src/tree.pyx"
+#line 492 "root_numpy/src/tree.pyx"
   __pyx_t_10.__pyx_n = 2;
 
-#line 474 "root_numpy/src/tree.pyx"
+#line 492 "root_numpy/src/tree.pyx"
   __pyx_t_10.name = __pyx_t_8;
 
-#line 474 "root_numpy/src/tree.pyx"
+#line 492 "root_numpy/src/tree.pyx"
   __pyx_t_10.tree = __pyx_v_tree;
 
-#line 474 "root_numpy/src/tree.pyx"
-  __pyx_t_9 = __pyx_f_13_librootnumpy_array2tree(((PyArrayObject *)__pyx_v_arr), &__pyx_t_10); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 474; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 492 "root_numpy/src/tree.pyx"
+  __pyx_t_9 = __pyx_f_13_librootnumpy_array2tree(((PyArrayObject *)__pyx_v_arr), &__pyx_t_10); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 474 "root_numpy/src/tree.pyx"
+#line 492 "root_numpy/src/tree.pyx"
   __pyx_v_tree = __pyx_t_9;
 
-  /* "root_numpy/src/tree.pyx":475
+  /* "root_numpy/src/tree.pyx":493
  *     cdef TTree* tree = <TTree*> rfile.Get(treename)
  *     tree = array2tree(arr, name=treename, tree=tree)
  *     tree.Write(treename, 2) # TObject::kOverwrite             # <<<<<<<<<<<<<<
@@ -23899,13 +24590,13 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     # TODO: clean up tree
  */
 
-#line 475 "root_numpy/src/tree.pyx"
-  __pyx_t_2 = __Pyx_PyObject_AsString(__pyx_v_treename); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 493 "root_numpy/src/tree.pyx"
+  __pyx_t_2 = __Pyx_PyObject_AsString(__pyx_v_treename); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 493; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 475 "root_numpy/src/tree.pyx"
+#line 493 "root_numpy/src/tree.pyx"
   __pyx_v_tree->Write(__pyx_t_2, 2);
 
-  /* "root_numpy/src/tree.pyx":476
+  /* "root_numpy/src/tree.pyx":494
  *     tree = array2tree(arr, name=treename, tree=tree)
  *     tree.Write(treename, 2) # TObject::kOverwrite
  *     rfile.Close()             # <<<<<<<<<<<<<<
@@ -23913,19 +24604,19 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     del rfile
  */
 
-#line 476 "root_numpy/src/tree.pyx"
+#line 494 "root_numpy/src/tree.pyx"
   __pyx_v_rfile->Close();
 
-  /* "root_numpy/src/tree.pyx":478
+  /* "root_numpy/src/tree.pyx":496
  *     rfile.Close()
  *     # TODO: clean up tree
  *     del rfile             # <<<<<<<<<<<<<<
  */
 
-#line 478 "root_numpy/src/tree.pyx"
+#line 496 "root_numpy/src/tree.pyx"
   delete __pyx_v_rfile;
 
-  /* "root_numpy/src/tree.pyx":466
+  /* "root_numpy/src/tree.pyx":484
  * 
  * 
  * def array2root(arr, filename, treename='tree', mode='update'):             # <<<<<<<<<<<<<<
@@ -23933,52 +24624,52 @@ static PyObject *__pyx_pf_13_librootnumpy_14array2root(CYTHON_UNUSED PyObject *_
  *     if rfile == NULL:
  */
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   /* function exit code */
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __pyx_r = Py_None; __Pyx_INCREF(Py_None);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   goto __pyx_L0;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __pyx_L1_error:;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_4);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_5);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_6);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_XDECREF(__pyx_t_7);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_AddTraceback("_librootnumpy.array2root", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __pyx_r = NULL;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __pyx_L0:;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_RefNannyFinishContext();
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   return __pyx_r;
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
 }
 
 /* "root_numpy/src/array.pyx":4
@@ -64429,6 +65120,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_PB, __pyx_k_PB, sizeof(__pyx_k_PB), 0, 0, 1, 1},
   {&__pyx_n_s_RootNumpyUnconvertibleWarning, __pyx_k_RootNumpyUnconvertibleWarning, sizeof(__pyx_k_RootNumpyUnconvertibleWarning), 0, 0, 1, 1},
   {&__pyx_n_s_RuntimeError, __pyx_k_RuntimeError, sizeof(__pyx_k_RuntimeError), 0, 0, 1, 1},
+  {&__pyx_n_s_RuntimeWarning, __pyx_k_RuntimeWarning, sizeof(__pyx_k_RuntimeWarning), 0, 0, 1, 1},
   {&__pyx_n_s_S, __pyx_k_S, sizeof(__pyx_k_S), 0, 0, 1, 1},
   {&__pyx_n_s_SPECIAL_TYPEDEFS, __pyx_k_SPECIAL_TYPEDEFS, sizeof(__pyx_k_SPECIAL_TYPEDEFS), 0, 0, 1, 1},
   {&__pyx_kp_s_S_0_d, __pyx_k_S_0_d, sizeof(__pyx_k_S_0_d), 0, 0, 1, 0},
@@ -64522,6 +65214,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_s_failed_to_allocate_memory_for_0, __pyx_k_failed_to_allocate_memory_for_0, sizeof(__pyx_k_failed_to_allocate_memory_for_0), 0, 0, 1, 0},
   {&__pyx_kp_s_field_0_of_type_1_is_not_compati, __pyx_k_field_0_of_type_1_is_not_compati, sizeof(__pyx_k_field_0_of_type_1_is_not_compati), 0, 0, 1, 0},
   {&__pyx_n_s_fields, __pyx_k_fields, sizeof(__pyx_k_fields), 0, 0, 1, 1},
+  {&__pyx_n_s_file, __pyx_k_file, sizeof(__pyx_k_file), 0, 0, 1, 1},
   {&__pyx_kp_s_file_0_is_not_writable, __pyx_k_file_0_is_not_writable, sizeof(__pyx_k_file_0_is_not_writable), 0, 0, 1, 0},
   {&__pyx_n_s_filename, __pyx_k_filename, sizeof(__pyx_k_filename), 0, 0, 1, 1},
   {&__pyx_n_s_fill_g1, __pyx_k_fill_g1, sizeof(__pyx_k_fill_g1), 0, 0, 1, 1},
@@ -64626,6 +65319,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_u_ndarray_is_not_C_contiguous, __pyx_k_ndarray_is_not_C_contiguous, sizeof(__pyx_k_ndarray_is_not_C_contiguous), 0, 1, 0, 0},
   {&__pyx_kp_u_ndarray_is_not_Fortran_contiguou, __pyx_k_ndarray_is_not_Fortran_contiguou, sizeof(__pyx_k_ndarray_is_not_Fortran_contiguou), 0, 1, 0, 0},
   {&__pyx_n_s_nkeys, __pyx_k_nkeys, sizeof(__pyx_k_nkeys), 0, 0, 1, 1},
+  {&__pyx_kp_s_none_of_the_input_files_contain, __pyx_k_none_of_the_input_files_contain, sizeof(__pyx_k_none_of_the_input_files_contain), 0, 0, 1, 0},
   {&__pyx_n_s_np, __pyx_k_np, sizeof(__pyx_k_np), 0, 0, 1, 1},
   {&__pyx_n_s_numpy, __pyx_k_numpy, sizeof(__pyx_k_numpy), 0, 0, 1, 1},
   {&__pyx_n_s_object, __pyx_k_object, sizeof(__pyx_k_object), 0, 0, 1, 1},
@@ -64678,7 +65372,6 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_s_tree_has_no_branches, __pyx_k_tree_has_no_branches, sizeof(__pyx_k_tree_has_no_branches), 0, 0, 1, 0},
   {&__pyx_kp_s_tree_index_in_chain_is_out_of_bo, __pyx_k_tree_index_in_chain_is_out_of_bo, sizeof(__pyx_k_tree_index_in_chain_is_out_of_bo), 0, 0, 1, 0},
   {&__pyx_n_s_treename, __pyx_k_treename, sizeof(__pyx_k_treename), 0, 0, 1, 1},
-  {&__pyx_n_s_ttree, __pyx_k_ttree, sizeof(__pyx_k_ttree), 0, 0, 1, 1},
   {&__pyx_n_s_uint16, __pyx_k_uint16, sizeof(__pyx_k_uint16), 0, 0, 1, 1},
   {&__pyx_n_s_uint32, __pyx_k_uint32, sizeof(__pyx_k_uint32), 0, 0, 1, 1},
   {&__pyx_n_s_uint64, __pyx_k_uint64, sizeof(__pyx_k_uint64), 0, 0, 1, 1},
@@ -64725,6 +65418,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_b_vector_vector_unsigned_long_long, __pyx_k_vector_vector_unsigned_long_long, sizeof(__pyx_k_vector_vector_unsigned_long_long), 0, 0, 0, 0},
   {&__pyx_kp_b_vector_vector_unsigned_short, __pyx_k_vector_vector_unsigned_short, sizeof(__pyx_k_vector_vector_unsigned_short), 0, 0, 0, 0},
   {&__pyx_n_s_warn, __pyx_k_warn, sizeof(__pyx_k_warn), 0, 0, 1, 1},
+  {&__pyx_n_s_warn_missing_tree, __pyx_k_warn_missing_tree, sizeof(__pyx_k_warn_missing_tree), 0, 0, 1, 1},
   {&__pyx_n_s_warnings, __pyx_k_warnings, sizeof(__pyx_k_warnings), 0, 0, 1, 1},
   {&__pyx_n_s_warnings_2, __pyx_k_warnings_2, sizeof(__pyx_k_warnings_2), 0, 0, 1, 1},
   {&__pyx_n_s_weight_name, __pyx_k_weight_name, sizeof(__pyx_k_weight_name), 0, 0, 1, 1},
@@ -64751,6 +65445,7 @@ static int __Pyx_InitCachedBuiltins(void) {
   #else
   __pyx_builtin_xrange = __Pyx_GetBuiltinName(__pyx_n_s_xrange); if (!__pyx_builtin_xrange) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 315; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   #endif
+  __pyx_builtin_RuntimeWarning = __Pyx_GetBuiltinName(__pyx_n_s_RuntimeWarning); if (!__pyx_builtin_RuntimeWarning) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 388; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   return 0;
   __pyx_L1_error:;
   return -1;
@@ -65725,7 +66420,7 @@ static int __Pyx_InitCachedConstants(void) {
  */
 
 #line 370 "root_numpy/src/tree.pyx"
-  __pyx_tuple__68 = PyTuple_Pack(13, __pyx_n_s_fnames, __pyx_n_s_treename, __pyx_n_s_branches, __pyx_n_s_selection, __pyx_n_s_start, __pyx_n_s_stop, __pyx_n_s_step, __pyx_n_s_include_weight, __pyx_n_s_weight_name, __pyx_n_s_cache_size, __pyx_n_s_ttree, __pyx_n_s_fn, __pyx_n_s_ret); if (unlikely(!__pyx_tuple__68)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_tuple__68 = PyTuple_Pack(16, __pyx_n_s_fnames, __pyx_n_s_treename, __pyx_n_s_branches, __pyx_n_s_selection, __pyx_n_s_start, __pyx_n_s_stop, __pyx_n_s_step, __pyx_n_s_include_weight, __pyx_n_s_weight_name, __pyx_n_s_cache_size, __pyx_n_s_warn_missing_tree, __pyx_n_s_chain, __pyx_n_s_file, __pyx_n_s_tree, __pyx_n_s_fn, __pyx_n_s_ret); if (unlikely(!__pyx_tuple__68)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
 #line 370 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_tuple__68);
@@ -65734,9 +66429,9 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__68);
 
 #line 370 "root_numpy/src/tree.pyx"
-  __pyx_codeobj__69 = (PyObject*)__Pyx_PyCode_New(10, 0, 13, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__68, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_root2array_fromfile, 370, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__69)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_codeobj__69 = (PyObject*)__Pyx_PyCode_New(11, 0, 16, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__68, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_root2array_fromfile, 370, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__69)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 370; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-  /* "root_numpy/src/tree.pyx":390
+  /* "root_numpy/src/tree.pyx":408
  * 
  * 
  * def root2array_fromtree(tree, branches, selection,             # <<<<<<<<<<<<<<
@@ -65744,19 +66439,19 @@ static int __Pyx_InitCachedConstants(void) {
  *                         bool include_weight, string weight_name,
  */
 
-#line 390 "root_numpy/src/tree.pyx"
-  __pyx_tuple__70 = PyTuple_Pack(10, __pyx_n_s_tree, __pyx_n_s_branches, __pyx_n_s_selection, __pyx_n_s_start, __pyx_n_s_stop, __pyx_n_s_step, __pyx_n_s_include_weight, __pyx_n_s_weight_name, __pyx_n_s_cache_size, __pyx_n_s_chain); if (unlikely(!__pyx_tuple__70)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 408 "root_numpy/src/tree.pyx"
+  __pyx_tuple__70 = PyTuple_Pack(10, __pyx_n_s_tree, __pyx_n_s_branches, __pyx_n_s_selection, __pyx_n_s_start, __pyx_n_s_stop, __pyx_n_s_step, __pyx_n_s_include_weight, __pyx_n_s_weight_name, __pyx_n_s_cache_size, __pyx_n_s_rtree); if (unlikely(!__pyx_tuple__70)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_tuple__70);
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_GIVEREF(__pyx_tuple__70);
 
-#line 390 "root_numpy/src/tree.pyx"
-  __pyx_codeobj__71 = (PyObject*)__Pyx_PyCode_New(9, 0, 10, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__70, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_root2array_fromtree, 390, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__71)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 408 "root_numpy/src/tree.pyx"
+  __pyx_codeobj__71 = (PyObject*)__Pyx_PyCode_New(9, 0, 10, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__70, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_root2array_fromtree, 408, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__71)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-  /* "root_numpy/src/tree.pyx":457
+  /* "root_numpy/src/tree.pyx":475
  * 
  * 
  * def array2tree_toCObj(arr, name='tree', tree=None):             # <<<<<<<<<<<<<<
@@ -65764,19 +66459,19 @@ static int __Pyx_InitCachedConstants(void) {
  *     cdef TTree* outtree = NULL
  */
 
-#line 457 "root_numpy/src/tree.pyx"
-  __pyx_tuple__72 = PyTuple_Pack(5, __pyx_n_s_arr, __pyx_n_s_name, __pyx_n_s_tree, __pyx_n_s_intree, __pyx_n_s_outtree); if (unlikely(!__pyx_tuple__72)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 475 "root_numpy/src/tree.pyx"
+  __pyx_tuple__72 = PyTuple_Pack(5, __pyx_n_s_arr, __pyx_n_s_name, __pyx_n_s_tree, __pyx_n_s_intree, __pyx_n_s_outtree); if (unlikely(!__pyx_tuple__72)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_tuple__72);
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_GIVEREF(__pyx_tuple__72);
 
-#line 457 "root_numpy/src/tree.pyx"
-  __pyx_codeobj__73 = (PyObject*)__Pyx_PyCode_New(3, 0, 5, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__72, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_array2tree_toCObj, 457, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__73)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 475 "root_numpy/src/tree.pyx"
+  __pyx_codeobj__73 = (PyObject*)__Pyx_PyCode_New(3, 0, 5, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__72, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_array2tree_toCObj, 475, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__73)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-  /* "root_numpy/src/tree.pyx":466
+  /* "root_numpy/src/tree.pyx":484
  * 
  * 
  * def array2root(arr, filename, treename='tree', mode='update'):             # <<<<<<<<<<<<<<
@@ -65784,17 +66479,17 @@ static int __Pyx_InitCachedConstants(void) {
  *     if rfile == NULL:
  */
 
-#line 466 "root_numpy/src/tree.pyx"
-  __pyx_tuple__74 = PyTuple_Pack(6, __pyx_n_s_arr, __pyx_n_s_filename, __pyx_n_s_treename, __pyx_n_s_mode, __pyx_n_s_rfile, __pyx_n_s_tree); if (unlikely(!__pyx_tuple__74)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 484 "root_numpy/src/tree.pyx"
+  __pyx_tuple__74 = PyTuple_Pack(6, __pyx_n_s_arr, __pyx_n_s_filename, __pyx_n_s_treename, __pyx_n_s_mode, __pyx_n_s_rfile, __pyx_n_s_tree); if (unlikely(!__pyx_tuple__74)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_tuple__74);
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_GIVEREF(__pyx_tuple__74);
 
-#line 466 "root_numpy/src/tree.pyx"
-  __pyx_codeobj__75 = (PyObject*)__Pyx_PyCode_New(4, 0, 6, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__74, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_array2root, 466, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__75)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 484 "root_numpy/src/tree.pyx"
+  __pyx_codeobj__75 = (PyObject*)__Pyx_PyCode_New(4, 0, 6, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__74, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_array2root, 484, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__75)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
   /* "root_numpy/src/array.pyx":10
  * 
@@ -71519,7 +72214,7 @@ goto __pyx_L16_unpacking_failed;
 #line 370 "root_numpy/src/tree.pyx"
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-  /* "root_numpy/src/tree.pyx":390
+  /* "root_numpy/src/tree.pyx":408
  * 
  * 
  * def root2array_fromtree(tree, branches, selection,             # <<<<<<<<<<<<<<
@@ -71527,19 +72222,19 @@ goto __pyx_L16_unpacking_failed;
  *                         bool include_weight, string weight_name,
  */
 
-#line 390 "root_numpy/src/tree.pyx"
-  __pyx_t_7 = PyCFunction_NewEx(&__pyx_mdef_13_librootnumpy_11root2array_fromtree, NULL, __pyx_n_s_librootnumpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 408 "root_numpy/src/tree.pyx"
+  __pyx_t_7 = PyCFunction_NewEx(&__pyx_mdef_13_librootnumpy_11root2array_fromtree, NULL, __pyx_n_s_librootnumpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_t_7);
 
-#line 390 "root_numpy/src/tree.pyx"
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_root2array_fromtree, __pyx_t_7) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 390; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 408 "root_numpy/src/tree.pyx"
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_root2array_fromtree, __pyx_t_7) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 408; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 390 "root_numpy/src/tree.pyx"
+#line 408 "root_numpy/src/tree.pyx"
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-  /* "root_numpy/src/tree.pyx":401
+  /* "root_numpy/src/tree.pyx":419
  * 
  * 
  * cdef TTree* array2tree(np.ndarray arr, string name='tree', TTree* tree=NULL) except *:             # <<<<<<<<<<<<<<
@@ -71547,13 +72242,13 @@ goto __pyx_L16_unpacking_failed;
  *     cdef NP2ROOTConverter* cvt
  */
 
-#line 401 "root_numpy/src/tree.pyx"
-  __pyx_t_17 = __pyx_convert_string_from_py_std__string(__pyx_n_b_tree); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 401; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 419 "root_numpy/src/tree.pyx"
+  __pyx_t_17 = __pyx_convert_string_from_py_std__string(__pyx_n_b_tree); if (unlikely(PyErr_Occurred())) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 419; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 401 "root_numpy/src/tree.pyx"
+#line 419 "root_numpy/src/tree.pyx"
   __pyx_k__34 = __pyx_t_17;
 
-  /* "root_numpy/src/tree.pyx":457
+  /* "root_numpy/src/tree.pyx":475
  * 
  * 
  * def array2tree_toCObj(arr, name='tree', tree=None):             # <<<<<<<<<<<<<<
@@ -71561,19 +72256,19 @@ goto __pyx_L16_unpacking_failed;
  *     cdef TTree* outtree = NULL
  */
 
-#line 457 "root_numpy/src/tree.pyx"
-  __pyx_t_7 = PyCFunction_NewEx(&__pyx_mdef_13_librootnumpy_13array2tree_toCObj, NULL, __pyx_n_s_librootnumpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 475 "root_numpy/src/tree.pyx"
+  __pyx_t_7 = PyCFunction_NewEx(&__pyx_mdef_13_librootnumpy_13array2tree_toCObj, NULL, __pyx_n_s_librootnumpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_t_7);
 
-#line 457 "root_numpy/src/tree.pyx"
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_array2tree_toCObj, __pyx_t_7) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 475 "root_numpy/src/tree.pyx"
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_array2tree_toCObj, __pyx_t_7) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 457 "root_numpy/src/tree.pyx"
+#line 475 "root_numpy/src/tree.pyx"
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-  /* "root_numpy/src/tree.pyx":466
+  /* "root_numpy/src/tree.pyx":484
  * 
  * 
  * def array2root(arr, filename, treename='tree', mode='update'):             # <<<<<<<<<<<<<<
@@ -71581,16 +72276,16 @@ goto __pyx_L16_unpacking_failed;
  *     if rfile == NULL:
  */
 
-#line 466 "root_numpy/src/tree.pyx"
-  __pyx_t_7 = PyCFunction_NewEx(&__pyx_mdef_13_librootnumpy_15array2root, NULL, __pyx_n_s_librootnumpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 484 "root_numpy/src/tree.pyx"
+  __pyx_t_7 = PyCFunction_NewEx(&__pyx_mdef_13_librootnumpy_15array2root, NULL, __pyx_n_s_librootnumpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_GOTREF(__pyx_t_7);
 
-#line 466 "root_numpy/src/tree.pyx"
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_array2root, __pyx_t_7) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+#line 484 "root_numpy/src/tree.pyx"
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_array2root, __pyx_t_7) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 466 "root_numpy/src/tree.pyx"
+#line 484 "root_numpy/src/tree.pyx"
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
   /* "root_numpy/src/array.pyx":10

--- a/root_numpy/src/root_numpy.pxi
+++ b/root_numpy/src/root_numpy.pxi
@@ -49,7 +49,7 @@ cdef extern from "Column.h":
 
 cdef extern from "TreeChain.h":
     cdef cppclass TreeChain:
-        TreeChain(TTree*, long_long)
+        TreeChain(TTree*, bool, long_long)
         int Prepare()
         int Next()
         void AddColumn(string, string, BranchColumn*)

--- a/root_numpy/tmva/src/_libtmvanumpy.cpp
+++ b/root_numpy/tmva/src/_libtmvanumpy.cpp
@@ -506,7 +506,7 @@ typedef struct {
 } __Pyx_BufFmt_Context;
 
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":723
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":723
  * # in Cython to enable them only on the right systems.
  * 
  * ctypedef npy_int8       int8_t             # <<<<<<<<<<<<<<
@@ -514,10 +514,10 @@ typedef struct {
  * ctypedef npy_int32      int32_t
  */
 
-#line 723 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 723 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_int8 __pyx_t_5numpy_int8_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":724
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":724
  * 
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t             # <<<<<<<<<<<<<<
@@ -525,10 +525,10 @@ typedef npy_int8 __pyx_t_5numpy_int8_t;
  * ctypedef npy_int64      int64_t
  */
 
-#line 724 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 724 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_int16 __pyx_t_5numpy_int16_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":725
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":725
  * ctypedef npy_int8       int8_t
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t             # <<<<<<<<<<<<<<
@@ -536,10 +536,10 @@ typedef npy_int16 __pyx_t_5numpy_int16_t;
  * #ctypedef npy_int96      int96_t
  */
 
-#line 725 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 725 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_int32 __pyx_t_5numpy_int32_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":726
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":726
  * ctypedef npy_int16      int16_t
  * ctypedef npy_int32      int32_t
  * ctypedef npy_int64      int64_t             # <<<<<<<<<<<<<<
@@ -547,10 +547,10 @@ typedef npy_int32 __pyx_t_5numpy_int32_t;
  * #ctypedef npy_int128     int128_t
  */
 
-#line 726 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 726 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_int64 __pyx_t_5numpy_int64_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":730
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":730
  * #ctypedef npy_int128     int128_t
  * 
  * ctypedef npy_uint8      uint8_t             # <<<<<<<<<<<<<<
@@ -558,10 +558,10 @@ typedef npy_int64 __pyx_t_5numpy_int64_t;
  * ctypedef npy_uint32     uint32_t
  */
 
-#line 730 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 730 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_uint8 __pyx_t_5numpy_uint8_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":731
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":731
  * 
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t             # <<<<<<<<<<<<<<
@@ -569,10 +569,10 @@ typedef npy_uint8 __pyx_t_5numpy_uint8_t;
  * ctypedef npy_uint64     uint64_t
  */
 
-#line 731 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 731 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_uint16 __pyx_t_5numpy_uint16_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":732
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":732
  * ctypedef npy_uint8      uint8_t
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t             # <<<<<<<<<<<<<<
@@ -580,10 +580,10 @@ typedef npy_uint16 __pyx_t_5numpy_uint16_t;
  * #ctypedef npy_uint96     uint96_t
  */
 
-#line 732 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 732 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_uint32 __pyx_t_5numpy_uint32_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":733
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":733
  * ctypedef npy_uint16     uint16_t
  * ctypedef npy_uint32     uint32_t
  * ctypedef npy_uint64     uint64_t             # <<<<<<<<<<<<<<
@@ -591,10 +591,10 @@ typedef npy_uint32 __pyx_t_5numpy_uint32_t;
  * #ctypedef npy_uint128    uint128_t
  */
 
-#line 733 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 733 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_uint64 __pyx_t_5numpy_uint64_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":737
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":737
  * #ctypedef npy_uint128    uint128_t
  * 
  * ctypedef npy_float32    float32_t             # <<<<<<<<<<<<<<
@@ -602,10 +602,10 @@ typedef npy_uint64 __pyx_t_5numpy_uint64_t;
  * #ctypedef npy_float80    float80_t
  */
 
-#line 737 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 737 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_float32 __pyx_t_5numpy_float32_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":738
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":738
  * 
  * ctypedef npy_float32    float32_t
  * ctypedef npy_float64    float64_t             # <<<<<<<<<<<<<<
@@ -613,10 +613,10 @@ typedef npy_float32 __pyx_t_5numpy_float32_t;
  * #ctypedef npy_float128   float128_t
  */
 
-#line 738 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 738 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_float64 __pyx_t_5numpy_float64_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":747
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":747
  * # The int types are mapped a bit surprising --
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t             # <<<<<<<<<<<<<<
@@ -624,10 +624,10 @@ typedef npy_float64 __pyx_t_5numpy_float64_t;
  * ctypedef npy_longlong   longlong_t
  */
 
-#line 747 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 747 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_long __pyx_t_5numpy_int_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":748
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":748
  * # numpy.int corresponds to 'l' and numpy.long to 'q'
  * ctypedef npy_long       int_t
  * ctypedef npy_longlong   long_t             # <<<<<<<<<<<<<<
@@ -635,10 +635,10 @@ typedef npy_long __pyx_t_5numpy_int_t;
  * 
  */
 
-#line 748 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 748 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_longlong __pyx_t_5numpy_long_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":749
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":749
  * ctypedef npy_long       int_t
  * ctypedef npy_longlong   long_t
  * ctypedef npy_longlong   longlong_t             # <<<<<<<<<<<<<<
@@ -646,10 +646,10 @@ typedef npy_longlong __pyx_t_5numpy_long_t;
  * ctypedef npy_ulong      uint_t
  */
 
-#line 749 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 749 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_longlong __pyx_t_5numpy_longlong_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":751
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":751
  * ctypedef npy_longlong   longlong_t
  * 
  * ctypedef npy_ulong      uint_t             # <<<<<<<<<<<<<<
@@ -657,10 +657,10 @@ typedef npy_longlong __pyx_t_5numpy_longlong_t;
  * ctypedef npy_ulonglong  ulonglong_t
  */
 
-#line 751 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 751 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_ulong __pyx_t_5numpy_uint_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":752
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":752
  * 
  * ctypedef npy_ulong      uint_t
  * ctypedef npy_ulonglong  ulong_t             # <<<<<<<<<<<<<<
@@ -668,10 +668,10 @@ typedef npy_ulong __pyx_t_5numpy_uint_t;
  * 
  */
 
-#line 752 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 752 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_ulonglong __pyx_t_5numpy_ulong_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":753
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":753
  * ctypedef npy_ulong      uint_t
  * ctypedef npy_ulonglong  ulong_t
  * ctypedef npy_ulonglong  ulonglong_t             # <<<<<<<<<<<<<<
@@ -679,10 +679,10 @@ typedef npy_ulonglong __pyx_t_5numpy_ulong_t;
  * ctypedef npy_intp       intp_t
  */
 
-#line 753 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 753 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":755
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":755
  * ctypedef npy_ulonglong  ulonglong_t
  * 
  * ctypedef npy_intp       intp_t             # <<<<<<<<<<<<<<
@@ -690,10 +690,10 @@ typedef npy_ulonglong __pyx_t_5numpy_ulonglong_t;
  * 
  */
 
-#line 755 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 755 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_intp __pyx_t_5numpy_intp_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":756
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":756
  * 
  * ctypedef npy_intp       intp_t
  * ctypedef npy_uintp      uintp_t             # <<<<<<<<<<<<<<
@@ -701,10 +701,10 @@ typedef npy_intp __pyx_t_5numpy_intp_t;
  * ctypedef npy_double     float_t
  */
 
-#line 756 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 756 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_uintp __pyx_t_5numpy_uintp_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":758
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":758
  * ctypedef npy_uintp      uintp_t
  * 
  * ctypedef npy_double     float_t             # <<<<<<<<<<<<<<
@@ -712,10 +712,10 @@ typedef npy_uintp __pyx_t_5numpy_uintp_t;
  * ctypedef npy_longdouble longdouble_t
  */
 
-#line 758 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 758 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_double __pyx_t_5numpy_float_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":759
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":759
  * 
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t             # <<<<<<<<<<<<<<
@@ -723,10 +723,10 @@ typedef npy_double __pyx_t_5numpy_float_t;
  * 
  */
 
-#line 759 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 759 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_double __pyx_t_5numpy_double_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":760
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":760
  * ctypedef npy_double     float_t
  * ctypedef npy_double     double_t
  * ctypedef npy_longdouble longdouble_t             # <<<<<<<<<<<<<<
@@ -734,7 +734,7 @@ typedef npy_double __pyx_t_5numpy_double_t;
  * ctypedef npy_cfloat      cfloat_t
  */
 
-#line 760 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 760 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_longdouble __pyx_t_5numpy_longdouble_t;
 
 /* "root_numpy/tmva/src/setup.pxi":27
@@ -829,7 +829,7 @@ struct arrayobject;
 typedef struct arrayobject arrayobject;
 #endif
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":762
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":762
  * ctypedef npy_longdouble longdouble_t
  * 
  * ctypedef npy_cfloat      cfloat_t             # <<<<<<<<<<<<<<
@@ -837,10 +837,10 @@ typedef struct arrayobject arrayobject;
  * ctypedef npy_clongdouble clongdouble_t
  */
 
-#line 762 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 762 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":763
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":763
  * 
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t             # <<<<<<<<<<<<<<
@@ -848,10 +848,10 @@ typedef npy_cfloat __pyx_t_5numpy_cfloat_t;
  * 
  */
 
-#line 763 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 763 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":764
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":764
  * ctypedef npy_cfloat      cfloat_t
  * ctypedef npy_cdouble     cdouble_t
  * ctypedef npy_clongdouble clongdouble_t             # <<<<<<<<<<<<<<
@@ -859,10 +859,10 @@ typedef npy_cdouble __pyx_t_5numpy_cdouble_t;
  * ctypedef npy_cdouble     complex_t
  */
 
-#line 764 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 764 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_clongdouble __pyx_t_5numpy_clongdouble_t;
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":766
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":766
  * ctypedef npy_clongdouble clongdouble_t
  * 
  * ctypedef npy_cdouble     complex_t             # <<<<<<<<<<<<<<
@@ -870,7 +870,7 @@ typedef npy_clongdouble __pyx_t_5numpy_clongdouble_t;
  * cdef inline object PyArray_MultiIterNew1(a):
  */
 
-#line 766 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 766 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 typedef npy_cdouble __pyx_t_5numpy_complex_t;
 #ifndef CYTHON_REFNANNY
   #define CYTHON_REFNANNY 0
@@ -1525,17 +1525,17 @@ static char __pyx_k_factory_add_events_twoclass[] = "factory_add_events_twoclass
 static char __pyx_k_ndarray_is_not_C_contiguous[] = "ndarray is not C contiguous";
 static char __pyx_k_factory_add_events_multiclass[] = "factory_add_events_multiclass";
 static char __pyx_k_factory_add_events_regression[] = "factory_add_events_regression";
-static char __pyx_k_home_endw_workspace_root_numpy[] = "/home/endw/workspace/root_numpy/root_numpy/tmva/src/factory.pyx";
+static char __pyx_k_imports_home_edawe_workspace_ro[] = "/imports/home/edawe/workspace/root_numpy/root_numpy/tmva/src/factory.pyx";
 static char __pyx_k_unknown_dtype_code_in_numpy_pxd[] = "unknown dtype code in numpy.pxd (%d)";
 static char __pyx_k_Format_string_allocated_too_shor[] = "Format string allocated too short, see comment in numpy.pxd";
 static char __pyx_k_Non_native_byte_order_not_suppor[] = "Non-native byte order not supported";
-static char __pyx_k_home_endw_workspace_root_numpy_2[] = "/home/endw/workspace/root_numpy/root_numpy/tmva/src/evaluate.pyx";
 static char __pyx_k_method_0_is_not_booked_in_this_r[] = "method '{0}' is not booked in this reader";
 static char __pyx_k_ndarray_is_not_Fortran_contiguou[] = "ndarray is not Fortran contiguous";
 static char __pyx_k_the_analysis_type_of_this_method[] = "the analysis type of this method is not supported";
 static char __pyx_k_there_must_be_at_least_one_regre[] = "there must be at least one regression target";
 static char __pyx_k_there_must_be_at_least_two_class[] = "there must be at least two classes";
 static char __pyx_k_this_method_was_trained_with_eve[] = "this method was trained with events containing {0} variables, but these events contain {1} variables";
+static char __pyx_k_imports_home_edawe_workspace_ro_2[] = "/imports/home/edawe/workspace/root_numpy/root_numpy/tmva/src/evaluate.pyx";
 static char __pyx_k_Format_string_allocated_too_shor_2[] = "Format string allocated too short.";
 static PyObject *__pyx_n_s_AssertionError;
 static PyObject *__pyx_n_b_Background;
@@ -1563,11 +1563,11 @@ static PyObject *__pyx_n_s_factory_add_events_regression;
 static PyObject *__pyx_n_s_factory_add_events_twoclass;
 static PyObject *__pyx_n_s_float32;
 static PyObject *__pyx_n_s_format;
-static PyObject *__pyx_kp_s_home_endw_workspace_root_numpy;
-static PyObject *__pyx_kp_s_home_endw_workspace_root_numpy_2;
 static PyObject *__pyx_n_s_i;
 static PyObject *__pyx_n_s_imeth;
 static PyObject *__pyx_n_s_import;
+static PyObject *__pyx_kp_s_imports_home_edawe_workspace_ro;
+static PyObject *__pyx_kp_s_imports_home_edawe_workspace_ro_2;
 static PyObject *__pyx_n_s_j;
 static PyObject *__pyx_n_s_label;
 static PyObject *__pyx_n_s_labels;
@@ -8666,7 +8666,7 @@ static CYTHON_INLINE void __pyx_f_7cpython_5array_zero(arrayobject *__pyx_v_self
 #line 159 "array.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":194
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":194
  *         # experimental exception made for __getbuffer__ and __releasebuffer__
  *         # -- the details of this may change.
  *         def __getbuffer__(ndarray self, Py_buffer* info, int flags):             # <<<<<<<<<<<<<<
@@ -8674,82 +8674,82 @@ static CYTHON_INLINE void __pyx_f_7cpython_5array_zero(arrayobject *__pyx_v_self
  *             # requirements, and does not yet fullfill the PEP.
  */
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 /* Python wrapper */
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_UNUSED int __pyx_pw_5numpy_7ndarray_1__getbuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags); /*proto*/
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_UNUSED int __pyx_pw_5numpy_7ndarray_1__getbuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags) {
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   int __pyx_r;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyDeclarations
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("__getbuffer__ (wrapper)", 0);
   __pyx_r = 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 __pyx_pf_5numpy_7ndarray___getbuffer__(((PyArrayObject *)__pyx_v_self), ((Py_buffer *)__pyx_v_info), ((int)__pyx_v_flags));
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags) {
   int __pyx_v_copy_shape
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_i
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_ndim
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_endian_detector
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_little_endian
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_t
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   char *__pyx_v_f
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   PyArray_Descr *__pyx_v_descr = 0
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_offset
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_hasfields
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
@@ -8763,22 +8763,22 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("__getbuffer__", 0);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_v_info != NULL) {
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->obj = Py_None; __Pyx_INCREF(Py_None);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GIVEREF(__pyx_v_info->obj);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":200
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":200
  *             # of flags
  * 
  *             if info == NULL: return             # <<<<<<<<<<<<<<
@@ -8786,22 +8786,22 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             cdef int copy_shape, i, ndim
  */
 
-#line 200 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 200 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = ((__pyx_v_info == NULL) != 0);
 
-#line 200 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 200 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-#line 200 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 200 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_r = 0;
 
-#line 200 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 200 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L0;
 
-#line 200 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 200 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":203
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":203
  * 
  *             cdef int copy_shape, i, ndim
  *             cdef int endian_detector = 1             # <<<<<<<<<<<<<<
@@ -8809,10 +8809,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  * 
  */
 
-#line 203 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 203 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_endian_detector = 1;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":204
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":204
  *             cdef int copy_shape, i, ndim
  *             cdef int endian_detector = 1
  *             cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)             # <<<<<<<<<<<<<<
@@ -8820,10 +8820,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             ndim = PyArray_NDIM(self)
  */
 
-#line 204 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 204 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_little_endian = ((((char *)(&__pyx_v_endian_detector))[0]) != 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":206
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":206
  *             cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)
  * 
  *             ndim = PyArray_NDIM(self)             # <<<<<<<<<<<<<<
@@ -8831,10 +8831,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):
  */
 
-#line 206 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 206 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_ndim = PyArray_NDIM(__pyx_v_self);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":208
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":208
  *             ndim = PyArray_NDIM(self)
  * 
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -8842,13 +8842,13 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             else:
  */
 
-#line 208 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 208 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = (((sizeof(npy_intp)) != (sizeof(Py_ssize_t))) != 0);
 
-#line 208 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 208 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":209
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":209
  * 
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):
  *                 copy_shape = 1             # <<<<<<<<<<<<<<
@@ -8856,19 +8856,19 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 copy_shape = 0
  */
 
-#line 209 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 209 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_copy_shape = 1;
 
-#line 209 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 209 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L4;
 
-#line 209 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 209 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 209 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 209 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /*else*/ {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":211
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":211
  *                 copy_shape = 1
  *             else:
  *                 copy_shape = 0             # <<<<<<<<<<<<<<
@@ -8876,16 +8876,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  */
 
-#line 211 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 211 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_copy_shape = 0;
 
-#line 211 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 211 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 211 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 211 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L4:;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":213
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":213
  *                 copy_shape = 0
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -8893,25 +8893,25 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 raise ValueError(u"ndarray is not C contiguous")
  */
 
-#line 213 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 213 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_2 = (((__pyx_v_flags & PyBUF_C_CONTIGUOUS) == PyBUF_C_CONTIGUOUS) != 0);
 
-#line 213 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 213 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_2) {
 
-#line 213 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 213 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   } else {
 
-#line 213 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 213 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_1 = __pyx_t_2;
 
-#line 213 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 213 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L6_bool_binop_done;
 
-#line 213 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 213 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":214
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":214
  * 
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_C_CONTIGUOUS)):             # <<<<<<<<<<<<<<
@@ -8919,19 +8919,19 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  * 
  */
 
-#line 214 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 214 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_2 = ((!(PyArray_CHKFLAGS(__pyx_v_self, NPY_C_CONTIGUOUS) != 0)) != 0);
 
-#line 214 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 214 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = __pyx_t_2;
 
-#line 214 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 214 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L6_bool_binop_done:;
 
-#line 214 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 214 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":215
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":215
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_C_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not C contiguous")             # <<<<<<<<<<<<<<
@@ -8939,25 +8939,25 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  */
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 215; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_t_3);
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_Raise(__pyx_t_3, 0, 0, 0);
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     {__pyx_filename = __pyx_f[3]; __pyx_lineno = 215; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":217
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":217
  *                 raise ValueError(u"ndarray is not C contiguous")
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)             # <<<<<<<<<<<<<<
@@ -8965,25 +8965,25 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 raise ValueError(u"ndarray is not Fortran contiguous")
  */
 
-#line 217 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 217 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_2 = (((__pyx_v_flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS) != 0);
 
-#line 217 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 217 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_2) {
 
-#line 217 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 217 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   } else {
 
-#line 217 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 217 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_1 = __pyx_t_2;
 
-#line 217 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 217 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L9_bool_binop_done;
 
-#line 217 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 217 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":218
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":218
  * 
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_F_CONTIGUOUS)):             # <<<<<<<<<<<<<<
@@ -8991,19 +8991,19 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  * 
  */
 
-#line 218 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 218 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_2 = ((!(PyArray_CHKFLAGS(__pyx_v_self, NPY_F_CONTIGUOUS) != 0)) != 0);
 
-#line 218 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 218 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = __pyx_t_2;
 
-#line 218 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 218 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L9_bool_binop_done:;
 
-#line 218 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 218 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":219
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":219
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_F_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not Fortran contiguous")             # <<<<<<<<<<<<<<
@@ -9011,25 +9011,25 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             info.buf = PyArray_DATA(self)
  */
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 219; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_t_3);
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_Raise(__pyx_t_3, 0, 0, 0);
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     {__pyx_filename = __pyx_f[3]; __pyx_lineno = 219; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":221
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":221
  *                 raise ValueError(u"ndarray is not Fortran contiguous")
  * 
  *             info.buf = PyArray_DATA(self)             # <<<<<<<<<<<<<<
@@ -9037,10 +9037,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             if copy_shape:
  */
 
-#line 221 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 221 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_info->buf = PyArray_DATA(__pyx_v_self);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":222
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":222
  * 
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim             # <<<<<<<<<<<<<<
@@ -9048,10 +9048,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 # Allocate new buffer for strides and shape info.
  */
 
-#line 222 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 222 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_info->ndim = __pyx_v_ndim;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":223
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":223
  *             info.buf = PyArray_DATA(self)
  *             info.ndim = ndim
  *             if copy_shape:             # <<<<<<<<<<<<<<
@@ -9059,13 +9059,13 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 # This is allocated as one block, strides first.
  */
 
-#line 223 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 223 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = (__pyx_v_copy_shape != 0);
 
-#line 223 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 223 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":226
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":226
  *                 # Allocate new buffer for strides and shape info.
  *                 # This is allocated as one block, strides first.
  *                 info.strides = <Py_ssize_t*>stdlib.malloc(sizeof(Py_ssize_t) * <size_t>ndim * 2)             # <<<<<<<<<<<<<<
@@ -9073,10 +9073,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 for i in range(ndim):
  */
 
-#line 226 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 226 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->strides = ((Py_ssize_t *)malloc((((sizeof(Py_ssize_t)) * ((size_t)__pyx_v_ndim)) * 2)));
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":227
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":227
  *                 # This is allocated as one block, strides first.
  *                 info.strides = <Py_ssize_t*>stdlib.malloc(sizeof(Py_ssize_t) * <size_t>ndim * 2)
  *                 info.shape = info.strides + ndim             # <<<<<<<<<<<<<<
@@ -9084,10 +9084,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                     info.strides[i] = PyArray_STRIDES(self)[i]
  */
 
-#line 227 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 227 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->shape = (__pyx_v_info->strides + __pyx_v_ndim);
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":228
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":228
  *                 info.strides = <Py_ssize_t*>stdlib.malloc(sizeof(Py_ssize_t) * <size_t>ndim * 2)
  *                 info.shape = info.strides + ndim
  *                 for i in range(ndim):             # <<<<<<<<<<<<<<
@@ -9095,16 +9095,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                     info.shape[i] = PyArray_DIMS(self)[i]
  */
 
-#line 228 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 228 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_4 = __pyx_v_ndim;
 
-#line 228 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 228 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=1) {
 
-#line 228 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 228 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_i = __pyx_t_5;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":229
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":229
  *                 info.shape = info.strides + ndim
  *                 for i in range(ndim):
  *                     info.strides[i] = PyArray_STRIDES(self)[i]             # <<<<<<<<<<<<<<
@@ -9112,10 +9112,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             else:
  */
 
-#line 229 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 229 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       (__pyx_v_info->strides[__pyx_v_i]) = (PyArray_STRIDES(__pyx_v_self)[__pyx_v_i]);
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":230
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":230
  *                 for i in range(ndim):
  *                     info.strides[i] = PyArray_STRIDES(self)[i]
  *                     info.shape[i] = PyArray_DIMS(self)[i]             # <<<<<<<<<<<<<<
@@ -9123,22 +9123,22 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)
  */
 
-#line 230 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 230 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       (__pyx_v_info->shape[__pyx_v_i]) = (PyArray_DIMS(__pyx_v_self)[__pyx_v_i]);
 
-#line 230 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 230 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 230 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 230 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L11;
 
-#line 230 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 230 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 230 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 230 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /*else*/ {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":232
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":232
  *                     info.shape[i] = PyArray_DIMS(self)[i]
  *             else:
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)             # <<<<<<<<<<<<<<
@@ -9146,10 +9146,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             info.suboffsets = NULL
  */
 
-#line 232 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 232 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->strides = ((Py_ssize_t *)PyArray_STRIDES(__pyx_v_self));
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":233
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":233
  *             else:
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)             # <<<<<<<<<<<<<<
@@ -9157,16 +9157,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             info.itemsize = PyArray_ITEMSIZE(self)
  */
 
-#line 233 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 233 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->shape = ((Py_ssize_t *)PyArray_DIMS(__pyx_v_self));
 
-#line 233 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 233 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 233 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 233 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L11:;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":234
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":234
  *                 info.strides = <Py_ssize_t*>PyArray_STRIDES(self)
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)
  *             info.suboffsets = NULL             # <<<<<<<<<<<<<<
@@ -9174,10 +9174,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             info.readonly = not PyArray_ISWRITEABLE(self)
  */
 
-#line 234 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 234 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_info->suboffsets = NULL;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":235
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":235
  *                 info.shape = <Py_ssize_t*>PyArray_DIMS(self)
  *             info.suboffsets = NULL
  *             info.itemsize = PyArray_ITEMSIZE(self)             # <<<<<<<<<<<<<<
@@ -9185,10 +9185,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  * 
  */
 
-#line 235 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 235 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_info->itemsize = PyArray_ITEMSIZE(__pyx_v_self);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":236
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":236
  *             info.suboffsets = NULL
  *             info.itemsize = PyArray_ITEMSIZE(self)
  *             info.readonly = not PyArray_ISWRITEABLE(self)             # <<<<<<<<<<<<<<
@@ -9196,10 +9196,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             cdef int t
  */
 
-#line 236 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 236 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_info->readonly = (!(PyArray_ISWRITEABLE(__pyx_v_self) != 0));
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":239
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":239
  * 
  *             cdef int t
  *             cdef char* f = NULL             # <<<<<<<<<<<<<<
@@ -9207,10 +9207,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             cdef list stack
  */
 
-#line 239 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 239 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_f = NULL;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":240
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":240
  *             cdef int t
  *             cdef char* f = NULL
  *             cdef dtype descr = self.descr             # <<<<<<<<<<<<<<
@@ -9218,19 +9218,19 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             cdef int offset
  */
 
-#line 240 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 240 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_3 = ((PyObject *)__pyx_v_self->descr);
 
-#line 240 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 240 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_INCREF(__pyx_t_3);
 
-#line 240 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 240 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_descr = ((PyArray_Descr *)__pyx_t_3);
 
-#line 240 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 240 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_3 = 0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":244
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":244
  *             cdef int offset
  * 
  *             cdef bint hasfields = PyDataType_HASFIELDS(descr)             # <<<<<<<<<<<<<<
@@ -9238,10 +9238,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             if not hasfields and not copy_shape:
  */
 
-#line 244 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 244 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_hasfields = PyDataType_HASFIELDS(__pyx_v_descr);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":246
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":246
  *             cdef bint hasfields = PyDataType_HASFIELDS(descr)
  * 
  *             if not hasfields and not copy_shape:             # <<<<<<<<<<<<<<
@@ -9249,37 +9249,37 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 info.obj = None
  */
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_2 = ((!(__pyx_v_hasfields != 0)) != 0);
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_2) {
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   } else {
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_1 = __pyx_t_2;
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L15_bool_binop_done;
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_2 = ((!(__pyx_v_copy_shape != 0)) != 0);
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = __pyx_t_2;
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L15_bool_binop_done:;
 
-#line 246 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 246 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":248
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":248
  *             if not hasfields and not copy_shape:
  *                 # do not call releasebuffer
  *                 info.obj = None             # <<<<<<<<<<<<<<
@@ -9287,31 +9287,31 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 # need to call releasebuffer
  */
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_INCREF(Py_None);
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GIVEREF(Py_None);
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_v_info->obj);
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(__pyx_v_info->obj);
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->obj = Py_None;
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L14;
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 248 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 248 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /*else*/ {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":251
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":251
  *             else:
  *                 # need to call releasebuffer
  *                 info.obj = self             # <<<<<<<<<<<<<<
@@ -9319,28 +9319,28 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             if not hasfields:
  */
 
-#line 251 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 251 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_INCREF(((PyObject *)__pyx_v_self));
 
-#line 251 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 251 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
 
-#line 251 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 251 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_v_info->obj);
 
-#line 251 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 251 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(__pyx_v_info->obj);
 
-#line 251 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 251 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->obj = ((PyObject *)__pyx_v_self);
 
-#line 251 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 251 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 251 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 251 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L14:;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":253
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":253
  *                 info.obj = self
  * 
  *             if not hasfields:             # <<<<<<<<<<<<<<
@@ -9348,13 +9348,13 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 if ((descr.byteorder == c'>' and little_endian) or
  */
 
-#line 253 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 253 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = ((!(__pyx_v_hasfields != 0)) != 0);
 
-#line 253 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 253 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":254
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":254
  * 
  *             if not hasfields:
  *                 t = descr.type_num             # <<<<<<<<<<<<<<
@@ -9362,13 +9362,13 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                     (descr.byteorder == c'<' and not little_endian)):
  */
 
-#line 254 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 254 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_4 = __pyx_v_descr->type_num;
 
-#line 254 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 254 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_t = __pyx_t_4;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":255
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":255
  *             if not hasfields:
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -9376,43 +9376,43 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                     raise ValueError(u"Non-native byte order not supported")
  */
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_2 = ((__pyx_v_descr->byteorder == '>') != 0);
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (!__pyx_t_2) {
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       goto __pyx_L20_next_or;
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     } else {
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_2 = (__pyx_v_little_endian != 0);
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (!__pyx_t_2) {
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     } else {
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_1 = __pyx_t_2;
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       goto __pyx_L19_bool_binop_done;
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 255 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 255 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_L20_next_or:;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":256
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":256
  *                 t = descr.type_num
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):             # <<<<<<<<<<<<<<
@@ -9420,37 +9420,37 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 if   t == NPY_BYTE:        f = "b"
  */
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_2 = ((__pyx_v_descr->byteorder == '<') != 0);
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (__pyx_t_2) {
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     } else {
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_1 = __pyx_t_2;
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       goto __pyx_L19_bool_binop_done;
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_2 = ((!(__pyx_v_little_endian != 0)) != 0);
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_1 = __pyx_t_2;
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_L19_bool_binop_done:;
 
-#line 256 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 256 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (__pyx_t_1) {
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":257
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":257
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -9458,25 +9458,25 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_UBYTE:       f = "B"
  */
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__6, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 257; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_Raise(__pyx_t_3, 0, 0, 0);
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       {__pyx_filename = __pyx_f[3]; __pyx_lineno = 257; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"
  *                 elif t == NPY_OBJECT:      f = "O"             # <<<<<<<<<<<<<<
@@ -9484,10 +9484,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  */
 
-#line 274 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 274 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     switch (__pyx_v_t) {
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":258
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":258
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")
  *                 if   t == NPY_BYTE:        f = "b"             # <<<<<<<<<<<<<<
@@ -9495,16 +9495,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_SHORT:       f = "h"
  */
 
-#line 258 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 258 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_BYTE:
 
-#line 258 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 258 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_b;
 
-#line 258 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 258 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":259
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":259
  *                     raise ValueError(u"Non-native byte order not supported")
  *                 if   t == NPY_BYTE:        f = "b"
  *                 elif t == NPY_UBYTE:       f = "B"             # <<<<<<<<<<<<<<
@@ -9512,16 +9512,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_USHORT:      f = "H"
  */
 
-#line 259 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 259 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_UBYTE:
 
-#line 259 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 259 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_B;
 
-#line 259 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 259 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":260
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":260
  *                 if   t == NPY_BYTE:        f = "b"
  *                 elif t == NPY_UBYTE:       f = "B"
  *                 elif t == NPY_SHORT:       f = "h"             # <<<<<<<<<<<<<<
@@ -9529,16 +9529,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_INT:         f = "i"
  */
 
-#line 260 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 260 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_SHORT:
 
-#line 260 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 260 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_h;
 
-#line 260 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 260 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":261
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":261
  *                 elif t == NPY_UBYTE:       f = "B"
  *                 elif t == NPY_SHORT:       f = "h"
  *                 elif t == NPY_USHORT:      f = "H"             # <<<<<<<<<<<<<<
@@ -9546,16 +9546,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_UINT:        f = "I"
  */
 
-#line 261 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 261 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_USHORT:
 
-#line 261 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 261 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_H;
 
-#line 261 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 261 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":262
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":262
  *                 elif t == NPY_SHORT:       f = "h"
  *                 elif t == NPY_USHORT:      f = "H"
  *                 elif t == NPY_INT:         f = "i"             # <<<<<<<<<<<<<<
@@ -9563,16 +9563,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_LONG:        f = "l"
  */
 
-#line 262 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 262 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_INT:
 
-#line 262 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 262 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_i;
 
-#line 262 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 262 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":263
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":263
  *                 elif t == NPY_USHORT:      f = "H"
  *                 elif t == NPY_INT:         f = "i"
  *                 elif t == NPY_UINT:        f = "I"             # <<<<<<<<<<<<<<
@@ -9580,16 +9580,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_ULONG:       f = "L"
  */
 
-#line 263 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 263 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_UINT:
 
-#line 263 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 263 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_I;
 
-#line 263 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 263 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":264
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":264
  *                 elif t == NPY_INT:         f = "i"
  *                 elif t == NPY_UINT:        f = "I"
  *                 elif t == NPY_LONG:        f = "l"             # <<<<<<<<<<<<<<
@@ -9597,16 +9597,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_LONGLONG:    f = "q"
  */
 
-#line 264 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 264 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_LONG:
 
-#line 264 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 264 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_l;
 
-#line 264 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 264 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":265
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":265
  *                 elif t == NPY_UINT:        f = "I"
  *                 elif t == NPY_LONG:        f = "l"
  *                 elif t == NPY_ULONG:       f = "L"             # <<<<<<<<<<<<<<
@@ -9614,16 +9614,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_ULONGLONG:   f = "Q"
  */
 
-#line 265 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 265 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_ULONG:
 
-#line 265 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 265 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_L;
 
-#line 265 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 265 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":266
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":266
  *                 elif t == NPY_LONG:        f = "l"
  *                 elif t == NPY_ULONG:       f = "L"
  *                 elif t == NPY_LONGLONG:    f = "q"             # <<<<<<<<<<<<<<
@@ -9631,16 +9631,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_FLOAT:       f = "f"
  */
 
-#line 266 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 266 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_LONGLONG:
 
-#line 266 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 266 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_q;
 
-#line 266 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 266 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":267
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":267
  *                 elif t == NPY_ULONG:       f = "L"
  *                 elif t == NPY_LONGLONG:    f = "q"
  *                 elif t == NPY_ULONGLONG:   f = "Q"             # <<<<<<<<<<<<<<
@@ -9648,16 +9648,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_DOUBLE:      f = "d"
  */
 
-#line 267 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 267 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_ULONGLONG:
 
-#line 267 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 267 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_Q;
 
-#line 267 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 267 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":268
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":268
  *                 elif t == NPY_LONGLONG:    f = "q"
  *                 elif t == NPY_ULONGLONG:   f = "Q"
  *                 elif t == NPY_FLOAT:       f = "f"             # <<<<<<<<<<<<<<
@@ -9665,16 +9665,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_LONGDOUBLE:  f = "g"
  */
 
-#line 268 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 268 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_FLOAT:
 
-#line 268 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 268 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_f;
 
-#line 268 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 268 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":269
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":269
  *                 elif t == NPY_ULONGLONG:   f = "Q"
  *                 elif t == NPY_FLOAT:       f = "f"
  *                 elif t == NPY_DOUBLE:      f = "d"             # <<<<<<<<<<<<<<
@@ -9682,16 +9682,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_CFLOAT:      f = "Zf"
  */
 
-#line 269 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 269 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_DOUBLE:
 
-#line 269 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 269 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_d;
 
-#line 269 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 269 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":270
  *                 elif t == NPY_FLOAT:       f = "f"
  *                 elif t == NPY_DOUBLE:      f = "d"
  *                 elif t == NPY_LONGDOUBLE:  f = "g"             # <<<<<<<<<<<<<<
@@ -9699,16 +9699,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  */
 
-#line 270 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 270 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_LONGDOUBLE:
 
-#line 270 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 270 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_g;
 
-#line 270 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 270 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":271
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":271
  *                 elif t == NPY_DOUBLE:      f = "d"
  *                 elif t == NPY_LONGDOUBLE:  f = "g"
  *                 elif t == NPY_CFLOAT:      f = "Zf"             # <<<<<<<<<<<<<<
@@ -9716,16 +9716,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"
  */
 
-#line 271 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 271 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_CFLOAT:
 
-#line 271 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 271 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_Zf;
 
-#line 271 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 271 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":272
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":272
  *                 elif t == NPY_LONGDOUBLE:  f = "g"
  *                 elif t == NPY_CFLOAT:      f = "Zf"
  *                 elif t == NPY_CDOUBLE:     f = "Zd"             # <<<<<<<<<<<<<<
@@ -9733,16 +9733,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 elif t == NPY_OBJECT:      f = "O"
  */
 
-#line 272 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 272 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_CDOUBLE:
 
-#line 272 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 272 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_Zd;
 
-#line 272 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 272 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":273
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":273
  *                 elif t == NPY_CFLOAT:      f = "Zf"
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"             # <<<<<<<<<<<<<<
@@ -9750,16 +9750,16 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 else:
  */
 
-#line 273 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 273 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_CLONGDOUBLE:
 
-#line 273 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 273 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_Zg;
 
-#line 273 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 273 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":274
  *                 elif t == NPY_CDOUBLE:     f = "Zd"
  *                 elif t == NPY_CLONGDOUBLE: f = "Zg"
  *                 elif t == NPY_OBJECT:      f = "O"             # <<<<<<<<<<<<<<
@@ -9767,19 +9767,19 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  */
 
-#line 274 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 274 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       case NPY_OBJECT:
 
-#line 274 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 274 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_k_O;
 
-#line 274 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 274 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-#line 274 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 274 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       default:
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":276
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":276
  *                 elif t == NPY_OBJECT:      f = "O"
  *                 else:
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)             # <<<<<<<<<<<<<<
@@ -9787,61 +9787,61 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 return
  */
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_t); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 276; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = PyUnicode_Format(__pyx_kp_u_unknown_dtype_code_in_numpy_pxd, __pyx_t_3); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 276; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_6);
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 276; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_6);
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GIVEREF(__pyx_t_6);
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = 0;
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 276; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_6);
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_Raise(__pyx_t_6, 0, 0, 0);
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       {__pyx_filename = __pyx_f[3]; __pyx_lineno = 276; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       break;
 
-#line 276 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 276 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":277
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":277
  *                 else:
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *                 info.format = f             # <<<<<<<<<<<<<<
@@ -9849,10 +9849,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             else:
  */
 
-#line 277 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 277 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->format = __pyx_v_f;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":278
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":278
  *                     raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *                 info.format = f
  *                 return             # <<<<<<<<<<<<<<
@@ -9860,19 +9860,19 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 info.format = <char*>stdlib.malloc(_buffer_format_string_len)
  */
 
-#line 278 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 278 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_r = 0;
 
-#line 278 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 278 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L0;
 
-#line 278 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 278 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 278 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 278 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /*else*/ {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":280
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":280
  *                 return
  *             else:
  *                 info.format = <char*>stdlib.malloc(_buffer_format_string_len)             # <<<<<<<<<<<<<<
@@ -9880,10 +9880,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 offset = 0
  */
 
-#line 280 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 280 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_info->format = ((char *)malloc(255));
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":281
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":281
  *             else:
  *                 info.format = <char*>stdlib.malloc(_buffer_format_string_len)
  *                 info.format[0] = c'^' # Native data types, manual alignment             # <<<<<<<<<<<<<<
@@ -9891,10 +9891,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 f = _util_dtypestring(descr, info.format + 1,
  */
 
-#line 281 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 281 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     (__pyx_v_info->format[0]) = '^';
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":282
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":282
  *                 info.format = <char*>stdlib.malloc(_buffer_format_string_len)
  *                 info.format[0] = c'^' # Native data types, manual alignment
  *                 offset = 0             # <<<<<<<<<<<<<<
@@ -9902,10 +9902,10 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                                       info.format + _buffer_format_string_len,
  */
 
-#line 282 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 282 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_offset = 0;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":283
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":283
  *                 info.format[0] = c'^' # Native data types, manual alignment
  *                 offset = 0
  *                 f = _util_dtypestring(descr, info.format + 1,             # <<<<<<<<<<<<<<
@@ -9913,13 +9913,13 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                                       &offset)
  */
 
-#line 283 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 283 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_7 = __pyx_f_5numpy__util_dtypestring(__pyx_v_descr, (__pyx_v_info->format + 1), (__pyx_v_info->format + 255), (&__pyx_v_offset)); if (unlikely(__pyx_t_7 == NULL)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 283; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 283 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 283 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_f = __pyx_t_7;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":286
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":286
  *                                       info.format + _buffer_format_string_len,
  *                                       &offset)
  *                 f[0] = c'\0' # Terminate format string             # <<<<<<<<<<<<<<
@@ -9927,13 +9927,13 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  */
 
-#line 286 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 286 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     (__pyx_v_f[0]) = '\x00';
 
-#line 286 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 286 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":194
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":194
  *         # experimental exception made for __getbuffer__ and __releasebuffer__
  *         # -- the details of this may change.
  *         def __getbuffer__(ndarray self, Py_buffer* info, int flags):             # <<<<<<<<<<<<<<
@@ -9941,79 +9941,79 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *             # requirements, and does not yet fullfill the PEP.
  */
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = 0;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L0;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L1_error:;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_3);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_6);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_AddTraceback("numpy.ndarray.__getbuffer__", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = -1;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_v_info != NULL && __pyx_v_info->obj != NULL) {
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_v_info->obj);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(__pyx_v_info->obj); __pyx_v_info->obj = NULL;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L2;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_v_info != NULL && __pyx_v_info->obj == Py_None) {
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(Py_None);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(Py_None); __pyx_v_info->obj = NULL;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L2:;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF((PyObject *)__pyx_v_descr);
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 194 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 194 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":288
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":288
  *                 f[0] = c'\0' # Terminate format string
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):             # <<<<<<<<<<<<<<
@@ -10021,51 +10021,51 @@ static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, P
  *                 stdlib.free(info.format)
  */
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 /* Python wrapper */
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_UNUSED void __pyx_pw_5numpy_7ndarray_3__releasebuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info); /*proto*/
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_UNUSED void __pyx_pw_5numpy_7ndarray_3__releasebuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info) {
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyDeclarations
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("__releasebuffer__ (wrapper)", 0);
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_pf_5numpy_7ndarray_2__releasebuffer__(((PyArrayObject *)__pyx_v_self), ((Py_buffer *)__pyx_v_info));
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info) {
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("__releasebuffer__", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":289
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":289
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):             # <<<<<<<<<<<<<<
@@ -10073,13 +10073,13 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):
  */
 
-#line 289 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 289 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = (PyArray_HASFIELDS(__pyx_v_self) != 0);
 
-#line 289 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 289 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":290
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":290
  *         def __releasebuffer__(ndarray self, Py_buffer* info):
  *             if PyArray_HASFIELDS(self):
  *                 stdlib.free(info.format)             # <<<<<<<<<<<<<<
@@ -10087,19 +10087,19 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  *                 stdlib.free(info.strides)
  */
 
-#line 290 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 290 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     free(__pyx_v_info->format);
 
-#line 290 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 290 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L3;
 
-#line 290 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 290 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 290 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 290 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L3:;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":291
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":291
  *             if PyArray_HASFIELDS(self):
  *                 stdlib.free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):             # <<<<<<<<<<<<<<
@@ -10107,13 +10107,13 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  *                 # info.shape was stored after info.strides in the same block
  */
 
-#line 291 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 291 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = (((sizeof(npy_intp)) != (sizeof(Py_ssize_t))) != 0);
 
-#line 291 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 291 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":292
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":292
  *                 stdlib.free(info.format)
  *             if sizeof(npy_intp) != sizeof(Py_ssize_t):
  *                 stdlib.free(info.strides)             # <<<<<<<<<<<<<<
@@ -10121,19 +10121,19 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  * 
  */
 
-#line 292 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 292 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     free(__pyx_v_info->strides);
 
-#line 292 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 292 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L4;
 
-#line 292 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 292 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 292 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 292 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L4:;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":288
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":288
  *                 f[0] = c'\0' # Terminate format string
  * 
  *         def __releasebuffer__(ndarray self, Py_buffer* info):             # <<<<<<<<<<<<<<
@@ -10141,19 +10141,19 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  *                 stdlib.free(info.format)
  */
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 288 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 288 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":768
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":768
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -10161,13 +10161,13 @@ static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_s
  * 
  */
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__pyx_v_a) {
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -10175,10 +10175,10 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew1", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":769
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":769
  * 
  * cdef inline object PyArray_MultiIterNew1(a):
  *     return PyArray_MultiIterNew(1, <void*>a)             # <<<<<<<<<<<<<<
@@ -10186,25 +10186,25 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
  * cdef inline object PyArray_MultiIterNew2(a, b):
  */
 
-#line 769 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 769 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_r);
 
-#line 769 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 769 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = PyArray_MultiIterNew(1, ((void *)__pyx_v_a)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 769; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 769 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 769 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_t_1);
 
-#line 769 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 769 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = __pyx_t_1;
 
-#line 769 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 769 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = 0;
 
-#line 769 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 769 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":768
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":768
  * ctypedef npy_cdouble     complex_t
  * 
  * cdef inline object PyArray_MultiIterNew1(a):             # <<<<<<<<<<<<<<
@@ -10212,40 +10212,40 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
  * 
  */
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L1_error:;
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_1);
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_AddTraceback("numpy.PyArray_MultiIterNew1", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = 0;
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 768 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 768 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":771
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":771
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -10253,13 +10253,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew1(PyObject *__
  * 
  */
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__pyx_v_a, PyObject *__pyx_v_b) {
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -10267,10 +10267,10 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew2", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":772
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":772
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)             # <<<<<<<<<<<<<<
@@ -10278,25 +10278,25 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
  * cdef inline object PyArray_MultiIterNew3(a, b, c):
  */
 
-#line 772 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 772 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_r);
 
-#line 772 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 772 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = PyArray_MultiIterNew(2, ((void *)__pyx_v_a), ((void *)__pyx_v_b)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 772; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 772 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 772 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_t_1);
 
-#line 772 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 772 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = __pyx_t_1;
 
-#line 772 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 772 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = 0;
 
-#line 772 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 772 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":771
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":771
  *     return PyArray_MultiIterNew(1, <void*>a)
  * 
  * cdef inline object PyArray_MultiIterNew2(a, b):             # <<<<<<<<<<<<<<
@@ -10304,40 +10304,40 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
  * 
  */
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L1_error:;
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_1);
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_AddTraceback("numpy.PyArray_MultiIterNew2", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = 0;
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 771 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 771 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":774
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":774
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -10345,13 +10345,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew2(PyObject *__
  * 
  */
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__pyx_v_a, PyObject *__pyx_v_b, PyObject *__pyx_v_c) {
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -10359,10 +10359,10 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew3", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":775
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":775
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)             # <<<<<<<<<<<<<<
@@ -10370,25 +10370,25 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):
  */
 
-#line 775 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 775 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_r);
 
-#line 775 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 775 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = PyArray_MultiIterNew(3, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 775; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 775 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 775 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_t_1);
 
-#line 775 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 775 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = __pyx_t_1;
 
-#line 775 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 775 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = 0;
 
-#line 775 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 775 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":774
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":774
  *     return PyArray_MultiIterNew(2, <void*>a, <void*>b)
  * 
  * cdef inline object PyArray_MultiIterNew3(a, b, c):             # <<<<<<<<<<<<<<
@@ -10396,40 +10396,40 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
  * 
  */
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L1_error:;
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_1);
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_AddTraceback("numpy.PyArray_MultiIterNew3", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = 0;
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 774 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 774 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":777
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":777
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -10437,13 +10437,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew3(PyObject *__
  * 
  */
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__pyx_v_a, PyObject *__pyx_v_b, PyObject *__pyx_v_c, PyObject *__pyx_v_d) {
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -10451,10 +10451,10 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew4", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":778
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":778
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)             # <<<<<<<<<<<<<<
@@ -10462,25 +10462,25 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):
  */
 
-#line 778 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 778 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_r);
 
-#line 778 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 778 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = PyArray_MultiIterNew(4, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c), ((void *)__pyx_v_d)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 778; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 778 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 778 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_t_1);
 
-#line 778 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 778 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = __pyx_t_1;
 
-#line 778 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 778 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = 0;
 
-#line 778 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 778 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":777
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":777
  *     return PyArray_MultiIterNew(3, <void*>a, <void*>b, <void*> c)
  * 
  * cdef inline object PyArray_MultiIterNew4(a, b, c, d):             # <<<<<<<<<<<<<<
@@ -10488,40 +10488,40 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
  * 
  */
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L1_error:;
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_1);
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_AddTraceback("numpy.PyArray_MultiIterNew4", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = 0;
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 777 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 777 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":780
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":780
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -10529,13 +10529,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew4(PyObject *__
  * 
  */
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__pyx_v_a, PyObject *__pyx_v_b, PyObject *__pyx_v_c, PyObject *__pyx_v_d, PyObject *__pyx_v_e) {
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -10543,10 +10543,10 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("PyArray_MultiIterNew5", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":781
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":781
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)             # <<<<<<<<<<<<<<
@@ -10554,25 +10554,25 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
  * cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:
  */
 
-#line 781 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 781 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_r);
 
-#line 781 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 781 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = PyArray_MultiIterNew(5, ((void *)__pyx_v_a), ((void *)__pyx_v_b), ((void *)__pyx_v_c), ((void *)__pyx_v_d), ((void *)__pyx_v_e)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 781; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 781 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 781 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_t_1);
 
-#line 781 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 781 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = __pyx_t_1;
 
-#line 781 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 781 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = 0;
 
-#line 781 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 781 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":780
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":780
  *     return PyArray_MultiIterNew(4, <void*>a, <void*>b, <void*>c, <void*> d)
  * 
  * cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):             # <<<<<<<<<<<<<<
@@ -10580,40 +10580,40 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
  * 
  */
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L1_error:;
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_1);
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_AddTraceback("numpy.PyArray_MultiIterNew5", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = 0;
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 780 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 780 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":783
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":783
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:             # <<<<<<<<<<<<<<
@@ -10621,34 +10621,34 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_PyArray_MultiIterNew5(PyObject *__
  *     # string. The new location in the format string is returned.
  */
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx_v_descr, char *__pyx_v_f, char *__pyx_v_end, int *__pyx_v_offset) {
   PyArray_Descr *__pyx_v_child = 0
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_endian_detector
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   int __pyx_v_little_endian
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   PyObject *__pyx_v_fields = 0
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   PyObject *__pyx_v_childname = NULL
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   PyObject *__pyx_v_new_offset = NULL
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   PyObject *__pyx_v_t = NULL
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   char *__pyx_r;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -10664,10 +10664,10 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("_util_dtypestring", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":790
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":790
  *     cdef int delta_offset
  *     cdef tuple i
  *     cdef int endian_detector = 1             # <<<<<<<<<<<<<<
@@ -10675,10 +10675,10 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *     cdef tuple fields
  */
 
-#line 790 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 790 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_endian_detector = 1;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":791
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":791
  *     cdef tuple i
  *     cdef int endian_detector = 1
  *     cdef bint little_endian = ((<char*>&endian_detector)[0] != 0)             # <<<<<<<<<<<<<<
@@ -10686,10 +10686,10 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  * 
  */
 
-#line 791 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 791 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_little_endian = ((((char *)(&__pyx_v_endian_detector))[0]) != 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":794
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":794
  *     cdef tuple fields
  * 
  *     for childname in descr.names:             # <<<<<<<<<<<<<<
@@ -10697,49 +10697,49 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *         child, new_offset = fields
  */
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (unlikely(__pyx_v_descr->names == Py_None)) {
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     {__pyx_filename = __pyx_f[3]; __pyx_lineno = 794; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = __pyx_v_descr->names; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   for (;;) {
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (__pyx_t_2 >= PyTuple_GET_SIZE(__pyx_t_1)) break;
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     #if CYTHON_COMPILING_IN_CPYTHON
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_3); __pyx_t_2++; if (unlikely(0 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 794; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     #else
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 794; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     #endif
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_XDECREF_SET(__pyx_v_childname, __pyx_t_3);
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = 0;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":795
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":795
  * 
  *     for childname in descr.names:
  *         fields = descr.fields[childname]             # <<<<<<<<<<<<<<
@@ -10747,22 +10747,22 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  * 
  */
 
-#line 795 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 795 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = PyObject_GetItem(__pyx_v_descr->fields, __pyx_v_childname); if (unlikely(__pyx_t_3 == NULL)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 795; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
 
-#line 795 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 795 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_t_3);
 
-#line 795 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 795 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (!(likely(PyTuple_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "tuple", Py_TYPE(__pyx_t_3)->tp_name), 0))) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 795; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 795 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 795 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_XDECREF_SET(__pyx_v_fields, ((PyObject*)__pyx_t_3));
 
-#line 795 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 795 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = 0;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":796
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":796
  *     for childname in descr.names:
  *         fields = descr.fields[childname]
  *         child, new_offset = fields             # <<<<<<<<<<<<<<
@@ -10770,100 +10770,100 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:
  */
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (likely(__pyx_v_fields != Py_None)) {
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       PyObject* sequence = __pyx_v_fields;
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       #if CYTHON_COMPILING_IN_CPYTHON
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       Py_ssize_t size = Py_SIZE(sequence);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       #else
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       Py_ssize_t size = PySequence_Size(sequence);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       #endif
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (unlikely(size != 2)) {
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         if (size > 2) __Pyx_RaiseTooManyValuesError(2);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         {__pyx_filename = __pyx_f[3]; __pyx_lineno = 796; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       #if CYTHON_COMPILING_IN_CPYTHON
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyTuple_GET_ITEM(sequence, 0); 
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyTuple_GET_ITEM(sequence, 1); 
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_INCREF(__pyx_t_3);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_INCREF(__pyx_t_4);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       #else
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 796; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 796; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       #endif
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     } else {
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_RaiseNoneNotIterableError(); {__pyx_filename = __pyx_f[3]; __pyx_lineno = 796; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_dtype))))) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 796; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_XDECREF_SET(__pyx_v_child, ((PyArray_Descr *)__pyx_t_3));
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = 0;
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_XDECREF_SET(__pyx_v_new_offset, __pyx_t_4);
 
-#line 796 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 796 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_4 = 0;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":798
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":798
  *         child, new_offset = fields
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:             # <<<<<<<<<<<<<<
@@ -10871,34 +10871,34 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  * 
  */
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_4 = __Pyx_PyInt_From_int((__pyx_v_offset[0])); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 798; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_t_4);
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_3 = PyNumber_Subtract(__pyx_v_new_offset, __pyx_t_4); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 798; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_GOTREF(__pyx_t_3);
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_5 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_5 == (int)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 798; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_6 = ((((__pyx_v_end - __pyx_v_f) - ((int)__pyx_t_5)) < 15) != 0);
 
-#line 798 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 798 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (__pyx_t_6) {
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":799
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":799
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")             # <<<<<<<<<<<<<<
@@ -10906,25 +10906,25 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *         if ((child.byteorder == c'>' and little_endian) or
  */
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_RuntimeError, __pyx_tuple__7, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 799; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_Raise(__pyx_t_3, 0, 0, 0);
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       {__pyx_filename = __pyx_f[3]; __pyx_lineno = 799; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":801
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":801
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")
  * 
  *         if ((child.byteorder == c'>' and little_endian) or             # <<<<<<<<<<<<<<
@@ -10932,43 +10932,43 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             raise ValueError(u"Non-native byte order not supported")
  */
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_7 = ((__pyx_v_child->byteorder == '>') != 0);
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (!__pyx_t_7) {
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       goto __pyx_L8_next_or;
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     } else {
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_7 = (__pyx_v_little_endian != 0);
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (!__pyx_t_7) {
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     } else {
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __pyx_t_7;
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       goto __pyx_L7_bool_binop_done;
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 801 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 801 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_L8_next_or:;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":802
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":802
  * 
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):             # <<<<<<<<<<<<<<
@@ -10976,37 +10976,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             # One could encode it in the format string and have Cython
  */
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_7 = ((__pyx_v_child->byteorder == '<') != 0);
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (__pyx_t_7) {
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     } else {
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __pyx_t_7;
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       goto __pyx_L7_bool_binop_done;
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_7 = ((!(__pyx_v_little_endian != 0)) != 0);
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_6 = __pyx_t_7;
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_L7_bool_binop_done:;
 
-#line 802 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 802 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (__pyx_t_6) {
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":803
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":803
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):
  *             raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -11014,25 +11014,25 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             # complain instead, BUT: < and > in format strings also imply
  */
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__8, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_Raise(__pyx_t_3, 0, 0, 0);
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       {__pyx_filename = __pyx_f[3]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":813
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":813
  * 
  *         # Output padding bytes
  *         while offset[0] < new_offset:             # <<<<<<<<<<<<<<
@@ -11040,31 +11040,31 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             f += 1
  */
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     while (1) {
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = __Pyx_PyInt_From_int((__pyx_v_offset[0])); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_t_3, __pyx_v_new_offset, Py_LT); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 813 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 813 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (!__pyx_t_6) break;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":814
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":814
  *         # Output padding bytes
  *         while offset[0] < new_offset:
  *             f[0] = 120 # "x"; pad byte             # <<<<<<<<<<<<<<
@@ -11072,10 +11072,10 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             offset[0] += 1
  */
 
-#line 814 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 814 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       (__pyx_v_f[0]) = 120;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":815
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":815
  *         while offset[0] < new_offset:
  *             f[0] = 120 # "x"; pad byte
  *             f += 1             # <<<<<<<<<<<<<<
@@ -11083,10 +11083,10 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  * 
  */
 
-#line 815 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 815 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = (__pyx_v_f + 1);
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":816
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":816
  *             f[0] = 120 # "x"; pad byte
  *             f += 1
  *             offset[0] += 1             # <<<<<<<<<<<<<<
@@ -11094,16 +11094,16 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *         offset[0] += child.itemsize
  */
 
-#line 816 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 816 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_8 = 0;
 
-#line 816 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 816 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       (__pyx_v_offset[__pyx_t_8]) = ((__pyx_v_offset[__pyx_t_8]) + 1);
 
-#line 816 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 816 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":818
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":818
  *             offset[0] += 1
  * 
  *         offset[0] += child.itemsize             # <<<<<<<<<<<<<<
@@ -11111,13 +11111,13 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *         if not PyDataType_HASFIELDS(child):
  */
 
-#line 818 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 818 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_8 = 0;
 
-#line 818 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 818 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     (__pyx_v_offset[__pyx_t_8]) = ((__pyx_v_offset[__pyx_t_8]) + __pyx_v_child->elsize);
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":820
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":820
  *         offset[0] += child.itemsize
  * 
  *         if not PyDataType_HASFIELDS(child):             # <<<<<<<<<<<<<<
@@ -11125,13 +11125,13 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             if end - f < 5:
  */
 
-#line 820 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 820 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_t_6 = ((!(PyDataType_HASFIELDS(__pyx_v_child) != 0)) != 0);
 
-#line 820 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 820 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     if (__pyx_t_6) {
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":821
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":821
  * 
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num             # <<<<<<<<<<<<<<
@@ -11139,19 +11139,19 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *                 raise RuntimeError(u"Format string allocated too short.")
  */
 
-#line 821 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 821 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_child->type_num); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 821; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 821 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 821 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 821 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 821 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_XDECREF_SET(__pyx_v_t, __pyx_t_4);
 
-#line 821 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 821 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = 0;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":822
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":822
  *         if not PyDataType_HASFIELDS(child):
  *             t = child.type_num
  *             if end - f < 5:             # <<<<<<<<<<<<<<
@@ -11159,13 +11159,13 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  * 
  */
 
-#line 822 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 822 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = (((__pyx_v_end - __pyx_v_f) < 5) != 0);
 
-#line 822 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 822 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-        /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":823
+        /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":823
  *             t = child.type_num
  *             if end - f < 5:
  *                 raise RuntimeError(u"Format string allocated too short.")             # <<<<<<<<<<<<<<
@@ -11173,25 +11173,25 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  */
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_RuntimeError, __pyx_tuple__9, NULL); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_GOTREF(__pyx_t_4);
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_Raise(__pyx_t_4, 0, 0, 0);
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         {__pyx_filename = __pyx_f[3]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":826
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":826
  * 
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"             # <<<<<<<<<<<<<<
@@ -11199,37 +11199,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"
  */
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_BYTE); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 826; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 826; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 826; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 98;
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 826 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 826 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":827
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":827
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"             # <<<<<<<<<<<<<<
@@ -11237,37 +11237,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"
  */
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_UBYTE); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 66;
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 827 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 827 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":828
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":828
  *             if   t == NPY_BYTE:        f[0] =  98 #"b"
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"             # <<<<<<<<<<<<<<
@@ -11275,37 +11275,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_INT:         f[0] = 105 #"i"
  */
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_SHORT); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 828; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 828; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 828; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 104;
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 828 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 828 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":829
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":829
  *             elif t == NPY_UBYTE:       f[0] =  66 #"B"
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"             # <<<<<<<<<<<<<<
@@ -11313,37 +11313,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_UINT:        f[0] =  73 #"I"
  */
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_USHORT); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 829; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 829; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 829; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 72;
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 829 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 829 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":830
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":830
  *             elif t == NPY_SHORT:       f[0] = 104 #"h"
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"
  *             elif t == NPY_INT:         f[0] = 105 #"i"             # <<<<<<<<<<<<<<
@@ -11351,37 +11351,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_LONG:        f[0] = 108 #"l"
  */
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_INT); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 105;
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 830 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 830 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":831
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":831
  *             elif t == NPY_USHORT:      f[0] =  72 #"H"
  *             elif t == NPY_INT:         f[0] = 105 #"i"
  *             elif t == NPY_UINT:        f[0] =  73 #"I"             # <<<<<<<<<<<<<<
@@ -11389,37 +11389,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"
  */
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_UINT); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 831; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 831; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 831; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 73;
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 831 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 831 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":832
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":832
  *             elif t == NPY_INT:         f[0] = 105 #"i"
  *             elif t == NPY_UINT:        f[0] =  73 #"I"
  *             elif t == NPY_LONG:        f[0] = 108 #"l"             # <<<<<<<<<<<<<<
@@ -11427,37 +11427,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
  */
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_LONG); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 832; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 832; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 832; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 108;
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 832 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 832 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":833
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":833
  *             elif t == NPY_UINT:        f[0] =  73 #"I"
  *             elif t == NPY_LONG:        f[0] = 108 #"l"
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"             # <<<<<<<<<<<<<<
@@ -11465,37 +11465,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
  */
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_ULONG); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 833; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 833; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 833; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 76;
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 833 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 833 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":834
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":834
  *             elif t == NPY_LONG:        f[0] = 108 #"l"
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"             # <<<<<<<<<<<<<<
@@ -11503,37 +11503,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"
  */
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_LONGLONG); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 834; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 834; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 834; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 113;
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 834 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 834 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":835
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":835
  *             elif t == NPY_ULONG:       f[0] = 76  #"L"
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"             # <<<<<<<<<<<<<<
@@ -11541,37 +11541,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
  */
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_ULONGLONG); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 835; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 835; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 835; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 81;
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 835 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 835 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":836
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":836
  *             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"             # <<<<<<<<<<<<<<
@@ -11579,37 +11579,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"
  */
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_FLOAT); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 836; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 836; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 836; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 102;
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 836 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 836 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":837
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":837
  *             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"             # <<<<<<<<<<<<<<
@@ -11617,37 +11617,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf
  */
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_DOUBLE); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 837; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 837; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 837; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 100;
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 837 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 837 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":838
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":838
  *             elif t == NPY_FLOAT:       f[0] = 102 #"f"
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"             # <<<<<<<<<<<<<<
@@ -11655,37 +11655,37 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd
  */
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_LONGDOUBLE); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 838; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 838; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 838; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 103;
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 838 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 838 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":839
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":839
  *             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf             # <<<<<<<<<<<<<<
@@ -11693,43 +11693,43 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_CLONGDOUBLE: f[0] = 90; f[1] = 103; f += 1 # Zg
  */
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_CFLOAT); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 839; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 839; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 839; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 90;
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[1]) = 102;
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_v_f = (__pyx_v_f + 1);
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 839 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 839 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":840
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":840
  *             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd             # <<<<<<<<<<<<<<
@@ -11737,43 +11737,43 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             elif t == NPY_OBJECT:      f[0] = 79 #"O"
  */
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_CDOUBLE); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 840; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 840; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 840; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 90;
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[1]) = 100;
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_v_f = (__pyx_v_f + 1);
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 840 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 840 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":841
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":841
  *             elif t == NPY_CFLOAT:      f[0] = 90; f[1] = 102; f += 1 # Zf
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd
  *             elif t == NPY_CLONGDOUBLE: f[0] = 90; f[1] = 103; f += 1 # Zg             # <<<<<<<<<<<<<<
@@ -11781,43 +11781,43 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             else:
  */
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyInt_FromLong(NPY_CLONGDOUBLE); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 841; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_3);
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyObject_RichCompare(__pyx_v_t, __pyx_t_3, Py_EQ); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 841; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 841; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 90;
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[1]) = 103;
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_v_f = (__pyx_v_f + 1);
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 841 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 841 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":842
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":842
  *             elif t == NPY_CDOUBLE:     f[0] = 90; f[1] = 100; f += 1 # Zd
  *             elif t == NPY_CLONGDOUBLE: f[0] = 90; f[1] = 103; f += 1 # Zg
  *             elif t == NPY_OBJECT:      f[0] = 79 #"O"             # <<<<<<<<<<<<<<
@@ -11825,40 +11825,40 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *                 raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  */
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_4 = PyInt_FromLong(NPY_OBJECT); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 842; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_GOTREF(__pyx_t_4);
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_3 = PyObject_RichCompare(__pyx_v_t, __pyx_t_4, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 842; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_6 < 0)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 842; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       if (__pyx_t_6) {
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         (__pyx_v_f[0]) = 79;
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         goto __pyx_L15;
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-#line 842 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 842 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       /*else*/ {
 
-        /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":844
+        /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":844
  *             elif t == NPY_OBJECT:      f[0] = 79 #"O"
  *             else:
  *                 raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)             # <<<<<<<<<<<<<<
@@ -11866,52 +11866,52 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *         else:
  */
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_t_3 = PyUnicode_Format(__pyx_kp_u_unknown_dtype_code_in_numpy_pxd, __pyx_v_t); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 844; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_GOTREF(__pyx_t_3);
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 844; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_GOTREF(__pyx_t_4);
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3);
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_GIVEREF(__pyx_t_3);
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_t_3 = 0;
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 844; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_GOTREF(__pyx_t_3);
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_Raise(__pyx_t_3, 0, 0, 0);
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
         {__pyx_filename = __pyx_f[3]; __pyx_lineno = 844; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       }
 
-#line 844 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 844 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_L15:;
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":845
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":845
  *             else:
  *                 raise ValueError(u"unknown dtype code in numpy.pxd (%d)" % t)
  *             f += 1             # <<<<<<<<<<<<<<
@@ -11919,19 +11919,19 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *             # Cython ignores struct boundary information ("T{...}"),
  */
 
-#line 845 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 845 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = (__pyx_v_f + 1);
 
-#line 845 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 845 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       goto __pyx_L13;
 
-#line 845 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 845 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 845 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 845 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     /*else*/ {
 
-      /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":849
+      /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":849
  *             # Cython ignores struct boundary information ("T{...}"),
  *             # so don't output it
  *             f = _util_dtypestring(child, f, end, offset)             # <<<<<<<<<<<<<<
@@ -11939,19 +11939,19 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  * 
  */
 
-#line 849 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 849 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_t_9 = __pyx_f_5numpy__util_dtypestring(__pyx_v_child, __pyx_v_f, __pyx_v_end, __pyx_v_offset); if (unlikely(__pyx_t_9 == NULL)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 849; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 849 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 849 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
       __pyx_v_f = __pyx_t_9;
 
-#line 849 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 849 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     }
 
-#line 849 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 849 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_L13:;
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":794
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":794
  *     cdef tuple fields
  * 
  *     for childname in descr.names:             # <<<<<<<<<<<<<<
@@ -11959,13 +11959,13 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *         child, new_offset = fields
  */
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 794 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 794 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":850
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":850
  *             # so don't output it
  *             f = _util_dtypestring(child, f, end, offset)
  *     return f             # <<<<<<<<<<<<<<
@@ -11973,13 +11973,13 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  * 
  */
 
-#line 850 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 850 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = __pyx_v_f;
 
-#line 850 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 850 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   goto __pyx_L0;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":783
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":783
  *     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
  * 
  * cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:             # <<<<<<<<<<<<<<
@@ -11987,58 +11987,58 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *     # string. The new location in the format string is returned.
  */
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L1_error:;
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_1);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_3);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_t_4);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_AddTraceback("numpy._util_dtypestring", __pyx_clineno, __pyx_lineno, __pyx_filename);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_r = NULL;
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF((PyObject *)__pyx_v_child);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_v_fields);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_v_childname);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_v_new_offset);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XDECREF(__pyx_v_t);
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 783 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 783 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":966
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":966
  * 
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -12046,22 +12046,22 @@ static CYTHON_INLINE char *__pyx_f_5numpy__util_dtypestring(PyArray_Descr *__pyx
  *      if base is None:
  */
 
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_arr, PyObject *__pyx_v_base) {
   PyObject *__pyx_v_baseptr
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 ;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
   int __pyx_t_2;
 
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("set_array_base", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":968
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":968
  * cdef inline void set_array_base(ndarray arr, object base):
  *      cdef PyObject* baseptr
  *      if base is None:             # <<<<<<<<<<<<<<
@@ -12069,16 +12069,16 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  *      else:
  */
 
-#line 968 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 968 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = (__pyx_v_base == Py_None);
 
-#line 968 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 968 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_2 = (__pyx_t_1 != 0);
 
-#line 968 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 968 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_2) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":969
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":969
  *      cdef PyObject* baseptr
  *      if base is None:
  *          baseptr = NULL             # <<<<<<<<<<<<<<
@@ -12086,19 +12086,19 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  *          Py_INCREF(base) # important to do this before decref below!
  */
 
-#line 969 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 969 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_baseptr = NULL;
 
-#line 969 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 969 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L3;
 
-#line 969 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 969 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 969 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 969 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /*else*/ {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":971
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":971
  *          baseptr = NULL
  *      else:
  *          Py_INCREF(base) # important to do this before decref below!             # <<<<<<<<<<<<<<
@@ -12106,10 +12106,10 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  *      Py_XDECREF(arr.base)
  */
 
-#line 971 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 971 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     Py_INCREF(__pyx_v_base);
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":972
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":972
  *      else:
  *          Py_INCREF(base) # important to do this before decref below!
  *          baseptr = <PyObject*>base             # <<<<<<<<<<<<<<
@@ -12117,16 +12117,16 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  *      arr.base = baseptr
  */
 
-#line 972 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 972 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_v_baseptr = ((PyObject *)__pyx_v_base);
 
-#line 972 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 972 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 972 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 972 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L3:;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":973
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":973
  *          Py_INCREF(base) # important to do this before decref below!
  *          baseptr = <PyObject*>base
  *      Py_XDECREF(arr.base)             # <<<<<<<<<<<<<<
@@ -12134,10 +12134,10 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  * 
  */
 
-#line 973 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 973 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   Py_XDECREF(__pyx_v_arr->base);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":974
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":974
  *          baseptr = <PyObject*>base
  *      Py_XDECREF(arr.base)
  *      arr.base = baseptr             # <<<<<<<<<<<<<<
@@ -12145,10 +12145,10 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  * cdef inline object get_array_base(ndarray arr):
  */
 
-#line 974 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 974 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_v_arr->base = __pyx_v_baseptr;
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":966
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":966
  * 
  * 
  * cdef inline void set_array_base(ndarray arr, object base):             # <<<<<<<<<<<<<<
@@ -12156,19 +12156,19 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  *      if base is None:
  */
 
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 966 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 966 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
-/* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":976
+/* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":976
  *      arr.base = baseptr
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -12176,21 +12176,21 @@ static CYTHON_INLINE void __pyx_f_5numpy_set_array_base(PyArrayObject *__pyx_v_a
  *         return None
  */
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__pyx_v_arr) {
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannySetupContext("get_array_base", 0);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":977
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":977
  * 
  * cdef inline object get_array_base(ndarray arr):
  *     if arr.base is NULL:             # <<<<<<<<<<<<<<
@@ -12198,13 +12198,13 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  *     else:
  */
 
-#line 977 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 977 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_t_1 = ((__pyx_v_arr->base == NULL) != 0);
 
-#line 977 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 977 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   if (__pyx_t_1) {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":978
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":978
  * cdef inline object get_array_base(ndarray arr):
  *     if arr.base is NULL:
  *         return None             # <<<<<<<<<<<<<<
@@ -12212,46 +12212,46 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  *         return <object>arr.base
  */
 
-#line 978 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 978 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_XDECREF(__pyx_r);
 
-#line 978 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 978 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_INCREF(Py_None);
 
-#line 978 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 978 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_r = Py_None;
 
-#line 978 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 978 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L0;
 
-#line 978 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 978 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-#line 978 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 978 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /*else*/ {
 
-    /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":980
+    /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":980
  *         return None
  *     else:
  *         return <object>arr.base             # <<<<<<<<<<<<<<
  */
 
-#line 980 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 980 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_XDECREF(__pyx_r);
 
-#line 980 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 980 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __Pyx_INCREF(((PyObject *)__pyx_v_arr->base));
 
-#line 980 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 980 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     __pyx_r = ((PyObject *)__pyx_v_arr->base);
 
-#line 980 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 980 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
     goto __pyx_L0;
 
-#line 980 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 980 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   }
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":976
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":976
  *      arr.base = baseptr
  * 
  * cdef inline object get_array_base(ndarray arr):             # <<<<<<<<<<<<<<
@@ -12259,25 +12259,25 @@ static CYTHON_INLINE PyObject *__pyx_f_5numpy_get_array_base(PyArrayObject *__py
  *         return None
  */
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   /* function exit code */
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_L0:;
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_XGIVEREF(__pyx_r);
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_RefNannyFinishContext();
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   return __pyx_r;
 
-#line 976 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 976 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
 }
 
 /* "string.from_py":13
@@ -12464,11 +12464,11 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_factory_add_events_twoclass, __pyx_k_factory_add_events_twoclass, sizeof(__pyx_k_factory_add_events_twoclass), 0, 0, 1, 1},
   {&__pyx_n_s_float32, __pyx_k_float32, sizeof(__pyx_k_float32), 0, 0, 1, 1},
   {&__pyx_n_s_format, __pyx_k_format, sizeof(__pyx_k_format), 0, 0, 1, 1},
-  {&__pyx_kp_s_home_endw_workspace_root_numpy, __pyx_k_home_endw_workspace_root_numpy, sizeof(__pyx_k_home_endw_workspace_root_numpy), 0, 0, 1, 0},
-  {&__pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_k_home_endw_workspace_root_numpy_2, sizeof(__pyx_k_home_endw_workspace_root_numpy_2), 0, 0, 1, 0},
   {&__pyx_n_s_i, __pyx_k_i, sizeof(__pyx_k_i), 0, 0, 1, 1},
   {&__pyx_n_s_imeth, __pyx_k_imeth, sizeof(__pyx_k_imeth), 0, 0, 1, 1},
   {&__pyx_n_s_import, __pyx_k_import, sizeof(__pyx_k_import), 0, 0, 1, 1},
+  {&__pyx_kp_s_imports_home_edawe_workspace_ro, __pyx_k_imports_home_edawe_workspace_ro, sizeof(__pyx_k_imports_home_edawe_workspace_ro), 0, 0, 1, 0},
+  {&__pyx_kp_s_imports_home_edawe_workspace_ro_2, __pyx_k_imports_home_edawe_workspace_ro_2, sizeof(__pyx_k_imports_home_edawe_workspace_ro_2), 0, 0, 1, 0},
   {&__pyx_n_s_j, __pyx_k_j, sizeof(__pyx_k_j), 0, 0, 1, 1},
   {&__pyx_n_s_label, __pyx_k_label, sizeof(__pyx_k_label), 0, 0, 1, 1},
   {&__pyx_n_s_labels, __pyx_k_labels, sizeof(__pyx_k_labels), 0, 0, 1, 1},
@@ -12569,7 +12569,7 @@ static int __Pyx_InitCachedConstants(void) {
 #line 47 "root_numpy/tmva/src/evaluate.pyx"
   __Pyx_GIVEREF(__pyx_tuple__3);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":215
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":215
  *             if ((flags & pybuf.PyBUF_C_CONTIGUOUS == pybuf.PyBUF_C_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_C_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not C contiguous")             # <<<<<<<<<<<<<<
@@ -12577,16 +12577,16 @@ static int __Pyx_InitCachedConstants(void) {
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  */
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_tuple__4 = PyTuple_Pack(1, __pyx_kp_u_ndarray_is_not_C_contiguous); if (unlikely(!__pyx_tuple__4)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 215; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_tuple__4);
 
-#line 215 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 215 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GIVEREF(__pyx_tuple__4);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":219
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":219
  *             if ((flags & pybuf.PyBUF_F_CONTIGUOUS == pybuf.PyBUF_F_CONTIGUOUS)
  *                 and not PyArray_CHKFLAGS(self, NPY_F_CONTIGUOUS)):
  *                 raise ValueError(u"ndarray is not Fortran contiguous")             # <<<<<<<<<<<<<<
@@ -12594,16 +12594,16 @@ static int __Pyx_InitCachedConstants(void) {
  *             info.buf = PyArray_DATA(self)
  */
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_tuple__5 = PyTuple_Pack(1, __pyx_kp_u_ndarray_is_not_Fortran_contiguou); if (unlikely(!__pyx_tuple__5)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 219; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_tuple__5);
 
-#line 219 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 219 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GIVEREF(__pyx_tuple__5);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":257
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":257
  *                 if ((descr.byteorder == c'>' and little_endian) or
  *                     (descr.byteorder == c'<' and not little_endian)):
  *                     raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -12611,16 +12611,16 @@ static int __Pyx_InitCachedConstants(void) {
  *                 elif t == NPY_UBYTE:       f = "B"
  */
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_tuple__6 = PyTuple_Pack(1, __pyx_kp_u_Non_native_byte_order_not_suppor); if (unlikely(!__pyx_tuple__6)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 257; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_tuple__6);
 
-#line 257 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 257 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GIVEREF(__pyx_tuple__6);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":799
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":799
  * 
  *         if (end - f) - <int>(new_offset - offset[0]) < 15:
  *             raise RuntimeError(u"Format string allocated too short, see comment in numpy.pxd")             # <<<<<<<<<<<<<<
@@ -12628,16 +12628,16 @@ static int __Pyx_InitCachedConstants(void) {
  *         if ((child.byteorder == c'>' and little_endian) or
  */
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_tuple__7 = PyTuple_Pack(1, __pyx_kp_u_Format_string_allocated_too_shor); if (unlikely(!__pyx_tuple__7)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 799; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_tuple__7);
 
-#line 799 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 799 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GIVEREF(__pyx_tuple__7);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":803
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":803
  *         if ((child.byteorder == c'>' and little_endian) or
  *             (child.byteorder == c'<' and not little_endian)):
  *             raise ValueError(u"Non-native byte order not supported")             # <<<<<<<<<<<<<<
@@ -12645,16 +12645,16 @@ static int __Pyx_InitCachedConstants(void) {
  *             # complain instead, BUT: < and > in format strings also imply
  */
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_tuple__8 = PyTuple_Pack(1, __pyx_kp_u_Non_native_byte_order_not_suppor); if (unlikely(!__pyx_tuple__8)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_tuple__8);
 
-#line 803 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 803 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GIVEREF(__pyx_tuple__8);
 
-  /* "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":823
+  /* "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd":823
  *             t = child.type_num
  *             if end - f < 5:
  *                 raise RuntimeError(u"Format string allocated too short.")             # <<<<<<<<<<<<<<
@@ -12662,13 +12662,13 @@ static int __Pyx_InitCachedConstants(void) {
  *             # Until ticket #99 is fixed, use integers to avoid warnings
  */
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __pyx_tuple__9 = PyTuple_Pack(1, __pyx_kp_u_Format_string_allocated_too_shor_2); if (unlikely(!__pyx_tuple__9)) {__pyx_filename = __pyx_f[3]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GOTREF(__pyx_tuple__9);
 
-#line 823 "../../.local/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
+#line 823 "../../../../rcs5_data/edawe/public/env/lib/python2.7/site-packages/Cython/Includes/numpy/__init__.pxd"
   __Pyx_GIVEREF(__pyx_tuple__9);
 
   /* "root_numpy/tmva/src/factory.pyx":4
@@ -12689,7 +12689,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__10);
 
 #line 4 "root_numpy/tmva/src/factory.pyx"
-  __pyx_codeobj__11 = (PyObject*)__Pyx_PyCode_New(6, 0, 15, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__10, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy, __pyx_n_s_factory_add_events_twoclass, 4, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__11)) {__pyx_filename = __pyx_f[1]; __pyx_lineno = 4; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_codeobj__11 = (PyObject*)__Pyx_PyCode_New(6, 0, 15, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__10, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_imports_home_edawe_workspace_ro, __pyx_n_s_factory_add_events_twoclass, 4, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__11)) {__pyx_filename = __pyx_f[1]; __pyx_lineno = 4; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
   /* "root_numpy/tmva/src/factory.pyx":36
  * @cython.boundscheck(False)
@@ -12709,7 +12709,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__12);
 
 #line 36 "root_numpy/tmva/src/factory.pyx"
-  __pyx_codeobj__13 = (PyObject*)__Pyx_PyCode_New(5, 0, 14, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__12, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy, __pyx_n_s_factory_add_events_multiclass, 36, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__13)) {__pyx_filename = __pyx_f[1]; __pyx_lineno = 36; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_codeobj__13 = (PyObject*)__Pyx_PyCode_New(5, 0, 14, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__12, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_imports_home_edawe_workspace_ro, __pyx_n_s_factory_add_events_multiclass, 36, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__13)) {__pyx_filename = __pyx_f[1]; __pyx_lineno = 36; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
   /* "root_numpy/tmva/src/factory.pyx":64
  * @cython.boundscheck(False)
@@ -12729,7 +12729,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__14);
 
 #line 64 "root_numpy/tmva/src/factory.pyx"
-  __pyx_codeobj__15 = (PyObject*)__Pyx_PyCode_New(5, 0, 14, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__14, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy, __pyx_n_s_factory_add_events_regression, 64, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__15)) {__pyx_filename = __pyx_f[1]; __pyx_lineno = 64; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_codeobj__15 = (PyObject*)__Pyx_PyCode_New(5, 0, 14, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__14, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_imports_home_edawe_workspace_ro, __pyx_n_s_factory_add_events_regression, 64, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__15)) {__pyx_filename = __pyx_f[1]; __pyx_lineno = 64; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
   /* "root_numpy/tmva/src/evaluate.pyx":3
  * @cython.boundscheck(False)
@@ -12749,7 +12749,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__16);
 
 #line 3 "root_numpy/tmva/src/evaluate.pyx"
-  __pyx_codeobj__17 = (PyObject*)__Pyx_PyCode_New(4, 0, 7, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__16, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_evaluate_reader, 3, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__17)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 3; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_codeobj__17 = (PyObject*)__Pyx_PyCode_New(4, 0, 7, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__16, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_imports_home_edawe_workspace_ro_2, __pyx_n_s_evaluate_reader, 3, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__17)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 3; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
   /* "root_numpy/tmva/src/evaluate.pyx":15
  * @cython.boundscheck(False)
@@ -12769,7 +12769,7 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__18);
 
 #line 15 "root_numpy/tmva/src/evaluate.pyx"
-  __pyx_codeobj__19 = (PyObject*)__Pyx_PyCode_New(3, 0, 4, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__18, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_home_endw_workspace_root_numpy_2, __pyx_n_s_evaluate_method, 15, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__19)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 15; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_codeobj__19 = (PyObject*)__Pyx_PyCode_New(3, 0, 4, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__18, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_imports_home_edawe_workspace_ro_2, __pyx_n_s_evaluate_method, 15, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__19)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 15; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
 #line 15 "root_numpy/tmva/src/evaluate.pyx"
   __Pyx_RefNannyFinishContext();


### PR DESCRIPTION
Provide an option to warn if a tree is missing from an input file istead of raising an IOError.

This is more convenient when globbing many files and some don't contain the requested tree due to how your production system operates (thinking of you, ATLAS...)