### PR TITLE
Add optional return_indices argument to stretch

### DIFF
--- a/root_numpy/_utils.py
+++ b/root_numpy/_utils.py
@@ -68,7 +68,7 @@ def stack(recs, fields=None):
     return np.hstack([rec[fields] for rec in recs])
 
 
-def stretch(arr, fields=None):
+def stretch(arr, fields=None, return_indices=False):
     """Stretch an array.
 
     Stretch an array by ``hstack()``-ing  multiple array fields while
@@ -81,6 +81,11 @@ def stretch(arr, fields=None):
         The array to be stretched.
     fields : list of strings, optional (default=None)
         A list of column names to stretch. If None, then stretch all fields.
+    return_indices : bool, optional (default=False)
+        If True, the array index of each stretched array entry will be
+        returned in addition to the stretched array.
+        This changes the return type of this function to a tuple consisting
+        of a structured array and a numpy int64 array.
 
     Returns
     -------
@@ -145,6 +150,10 @@ def stretch(arr, fields=None):
             # Scalar field
             ret[field] = np.repeat(arr[field], len_array)
 
+    if return_indices:
+        idx = np.concatenate(map(np.arange, len_array))
+        return ret, idx
+    
     return ret
 
 

--- a/root_numpy/_utils.py
+++ b/root_numpy/_utils.py
@@ -151,7 +151,7 @@ def stretch(arr, fields=None, return_indices=False):
             ret[field] = np.repeat(arr[field], len_array)
 
     if return_indices:
-        idx = np.concatenate(map(np.arange, len_array))
+        idx = np.concatenate(list(map(np.arange, len_array)))
         return ret, idx
     
     return ret

--- a/root_numpy/tests.py
+++ b/root_numpy/tests.py
@@ -641,7 +641,7 @@ def test_stretch():
     stretched, idx = rnp.stretch(arr, ['scalar', 'vl1'], return_indices=True)
     assert_equal(stretched.shape[0], idx.shape[0])
 
-    from_arr = map(lambda x: x['vl1'][0], arr)
+    from_arr = list(map(lambda x: x['vl1'][0], arr))
     from_stretched = stretched[idx == 0]['vl1']
     assert_array_equal(from_arr, from_stretched)
 

--- a/root_numpy/tests.py
+++ b/root_numpy/tests.py
@@ -637,6 +637,14 @@ def test_stretch():
     assert_array_equal(
         stretched['scalar'], np.repeat(arr['scalar'], 2))
 
+    # optional argument return_indices
+    stretched, idx = rnp.stretch(arr, ['scalar', 'vl1'], return_indices=True)
+    assert_equal(stretched.shape[0], idx.shape[0])
+
+    from_arr = map(lambda x: x['vl1'][0], arr)
+    from_stretched = stretched[idx == 0]['vl1']
+    assert_array_equal(from_arr, from_stretched)
+
 
 def test_blockwise_inner_join():
     test_data = np.array([


### PR DESCRIPTION
When using `stretch`, information about the array index is lost in the stretched record array.
It would be nice if we could retain that information with an optional argument like implemented in this PR.

When `return_indices=True`, `stretch` returns an index array in addition to the structured array.
An alternative would be to store the information in a new field in the structured array, but here we would have to assume a name for that field, and users might not expect their array to gain a new field when ~~calling the function~~ supplying the optional argument.