### PR TITLE
[MRG] Add DeprecationWarnings for tree2rec and root2rec

### DIFF
--- a/root_numpy/__init__.py
+++ b/root_numpy/__init__.py
@@ -10,7 +10,7 @@ from ._sample import random_sample
 from ._array import array
 from ._matrix import matrix
 from ._evaluate import evaluate
-from ._warnings import RootNumpyWarning, RootNumpyUnconvertibleWarning
+from ._warnings import RootNumpyUnconvertibleWarning
 from ._utils import (
     stretch, blockwise_inner_join,
     rec2array, stack, dup_idx)
@@ -42,6 +42,12 @@ __all__ = [
     'stretch',
     'dup_idx',
     'blockwise_inner_join',
-    'RootNumpyWarning',
     'RootNumpyUnconvertibleWarning',
 ]
+
+import warnings
+import re
+
+# Make sure that DeprecationWarning within this package always gets printed
+warnings.filterwarnings('always', category=DeprecationWarning,
+                        module='^{0}\.'.format(re.escape(__name__)))

--- a/root_numpy/_tree.py
+++ b/root_numpy/_tree.py
@@ -1,3 +1,4 @@
+import warnings
 from glob import glob
 import numpy as np
 
@@ -377,6 +378,9 @@ def tree2rec(tree,
     tree2array
 
     """
+    warnings.warn("tree2rec is deprecated and will be removed in 4.5.0. "
+                  "Instead use tree2array(...).view(np.recarray)",
+                  DeprecationWarning)
     return tree2array(tree,
                       branches=branches,
                       selection=selection,

--- a/root_numpy/_tree.py
+++ b/root_numpy/_tree.py
@@ -231,6 +231,9 @@ def root2rec(filenames,
     root2array
 
     """
+    warnings.warn("root2rec is deprecated and will be removed in 4.5.0. "
+                  "Instead use root2array(...).view(np.recarray)",
+                  DeprecationWarning)
     return root2array(filenames, treename,
                       branches, selection,
                       start, stop, step,

--- a/root_numpy/_warnings.py
+++ b/root_numpy/_warnings.py
@@ -2,17 +2,11 @@ import warnings
 
 
 __all__ = [
-    'RootNumpyWarning',
     'RootNumpyUnconvertibleWarning',
 ]
 
 
-class RootNumpyWarning(RuntimeWarning):
-    pass
-
-
-class RootNumpyUnconvertibleWarning(RootNumpyWarning):
+class RootNumpyUnconvertibleWarning(RuntimeWarning):
     pass
 
 warnings.simplefilter('always', RootNumpyUnconvertibleWarning)
-warnings.simplefilter('always', RootNumpyWarning)


### PR DESCRIPTION
These functions will be removed in 4.5.0

```python
>>> from root_numpy import root2rec
>>> root2rec("root_numpy/testdata/single1.root")
root_numpy/_tree.py:236: DeprecationWarning: root2rec is deprecated and will be removed in 4.5.0. Instead use root2array(...).view(np.recarray)
  DeprecationWarning)
rec.array([(1, 1.0, 1.0), (2, 3.0, 4.0), (3, 5.0, 7.0), (4, 7.0, 10.0),
 (5, 9.0, 13.0), (6, 11.0, 16.0), (7, 13.0, 19.0), (8, 15.0, 22.0),
 (9, 17.0, 25.0), (10, 19.0, 28.0), (11, 21.0, 31.0), (12, 23.0, 34.0),
 (13, 25.0, 37.0), (14, 27.0, 40.0), (15, 29.0, 43.0), (16, 31.0, 46.0),
 (17, 33.0, 49.0), (18, 35.0, 52.0), (19, 37.0, 55.0), (20, 39.0, 58.0),
...
```