### PR TITLE
[WIP] Implement #136: Warn if current version of ROOT or NumPy is different than version built against

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,12 @@ include = */root_numpy/*
 omit =
     */root/*
     */root_numpy/extern/*
+    */root_numpy/setup_utils.py
     */setup.py
 [report]
 exclude_lines =
+    # Enable the standard pragma
+    pragma: no cover
+    # Don't complain if tests don't hit defensive assertion code
     raise AssertionError
+    raise NotImplementedError

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 MANIFEST
 root_numpy/src/*.html
+root_numpy/config.json
 build
 dist
 coverage

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 
 `[see full documentation] <http://rootpy.github.com/root_numpy/>`_
 
-root_numpy
-==========
+root_numpy: The interface between ROOT and NumPy
+================================================
 
 .. image:: https://img.shields.io/pypi/v/root_numpy.svg
    :target: https://pypi.python.org/pypi/root_numpy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ root_numpy
 
 .. raw:: html
 
-   <h2 class="main-subtitle">An interface between ROOT and NumPy</h2>
+   <h2 class="main-subtitle">The interface between ROOT and NumPy</h2>
 
 .. include:: ../README.rst
    :start-line: 20

--- a/root_numpy/__init__.py
+++ b/root_numpy/__init__.py
@@ -1,3 +1,41 @@
+import warnings
+import re
+
+# Make sure that DeprecationWarning within this package always gets printed
+warnings.filterwarnings('always', category=DeprecationWarning,
+                        module='^{0}\.'.format(re.escape(__name__)))
+
+from .setup_utils import root_version_active, get_config
+
+ROOT_VERSION = root_version_active()
+config = get_config()
+
+if config is not None:
+    root_version_at_install = config['ROOT_version']
+    numpy_version_at_install = config['numpy_version']
+
+    if ROOT_VERSION != root_version_at_install:
+        warnings.warn(
+            "ROOT {0} is currently active but you "
+            "installed root_numpy against ROOT {1}. "
+            "Please consider reinstalling root_numpy "
+            "for this ROOT version.".format(
+                ROOT_VERSION, root_version_at_install),
+            RuntimeWarning)
+
+    import numpy
+    if numpy.__version__ != numpy_version_at_install:
+        warnings.warn(
+            "numpy {0} is currently installed but you "
+            "installed root_numpy against numpy {1}. "
+            "Please consider reinstalling root_numpy "
+            "for this numpy version.".format(
+                numpy.__version__, numpy_version_at_install),
+            RuntimeWarning)
+
+    del root_version_at_install
+    del numpy_version_at_install
+
 from ._tree import (
     root2array, root2rec,
     tree2array, tree2rec,
@@ -44,10 +82,3 @@ __all__ = [
     'blockwise_inner_join',
     'RootNumpyUnconvertibleWarning',
 ]
-
-import warnings
-import re
-
-# Make sure that DeprecationWarning within this package always gets printed
-warnings.filterwarnings('always', category=DeprecationWarning,
-                        module='^{0}\.'.format(re.escape(__name__)))

--- a/root_numpy/__init__.py
+++ b/root_numpy/__init__.py
@@ -11,8 +11,7 @@ ROOT_VERSION = root_version_active()
 config = get_config()
 
 if config is not None:  # pragma: no cover
-    root_version_at_install = config['ROOT_version']
-    numpy_version_at_install = config['numpy_version']
+    root_version_at_install = config.get('ROOT_version', ROOT_VERSION)
 
     if ROOT_VERSION != root_version_at_install:
         warnings.warn(
@@ -24,6 +23,8 @@ if config is not None:  # pragma: no cover
             RuntimeWarning)
 
     import numpy
+    numpy_version_at_install = config.get('numpy_version', numpy.__version__)
+
     if numpy.__version__ != numpy_version_at_install:
         warnings.warn(
             "numpy {0} is currently installed but you "

--- a/root_numpy/__init__.py
+++ b/root_numpy/__init__.py
@@ -10,7 +10,7 @@ from .setup_utils import root_version_active, get_config
 ROOT_VERSION = root_version_active()
 config = get_config()
 
-if config is not None:
+if config is not None:  # pragma: no cover
     root_version_at_install = config['ROOT_version']
     numpy_version_at_install = config['numpy_version']
 

--- a/root_numpy/setup_utils.py
+++ b/root_numpy/setup_utils.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+
+
+def root_flags(root_config='root-config'):
+    root_cflags = subprocess.Popen(
+        [root_config, '--cflags'],
+        stdout=subprocess.PIPE).communicate()[0].strip()
+    root_ldflags = subprocess.Popen(
+        [root_config, '--libs'],
+        stdout=subprocess.PIPE).communicate()[0].strip()
+    if sys.version > '3':
+        root_cflags = root_cflags.decode('utf-8')
+        root_ldflags = root_ldflags.decode('utf-8')
+    return root_cflags.split(), root_ldflags.split()
+
+
+def root_has_feature(feature, root_config='root-config'):
+    if os.getenv('NO_ROOT_NUMPY_{0}'.format(feature.upper())):
+        # override
+        return False
+    has_feature = subprocess.Popen(
+        [root_config, '--has-{0}'.format(feature)],
+        stdout=subprocess.PIPE).communicate()[0].strip()
+    if sys.version > '3':
+        has_feature = has_feature.decode('utf-8')
+    return has_feature == 'yes'
+
+
+def root_version_installed(root_config='root-config'):
+    root_vers = subprocess.Popen(
+        [root_config, '--version'],
+        stdout=subprocess.PIPE).communicate()[0].strip()
+    if sys.version > '3':
+        root_vers = root_vers.decode('utf-8')
+    return root_vers
+
+
+def root_version_active():
+    import ROOT
+    return ROOT.gROOT.GetVersion()
+
+
+def get_config():
+    from pkg_resources import resource_filename
+    config_path = resource_filename('root_numpy', 'config.json')
+    if not os.path.isfile(config_path):
+        return None
+    import json
+    with open(config_path, 'r') as config_file:
+        config = json.load(config_file)
+    return config


### PR DESCRIPTION
xref #136 

Installation now writes a config.json in root_numpy containing the ROOT and numpy versions present at install time. Then root_numpy will warn if current versions ever differ.