### PR TITLE
check for inheritance in list_objects_recursive

### DIFF
--- a/root_numpy/_utils.py
+++ b/root_numpy/_utils.py
@@ -153,7 +153,7 @@ def stretch(arr, fields=None, return_indices=False):
     if return_indices:
         idx = np.concatenate(list(map(np.arange, len_array)))
         return ret, idx
-    
+
     return ret
 
 

--- a/root_numpy/src/tree.pyx
+++ b/root_numpy/src/tree.pyx
@@ -11,13 +11,9 @@ cdef list_objects_recursive(TDirectory* rdir, objects, types=None, path=""):
         key = <TKey*> keys.At(i)
         clsname = str(key.GetClassName())
         cl = ROOT.gROOT.GetClass(clsname)
-        if types is None:
-            objects.append(path + str(key.GetName()))
-        else:
-            for t in types:
-                if cl.InheritsFrom(ROOT.gROOT.GetClass(t)):
+        if types is None or\
+                numpy.any([cl.InheritsFrom(ROOT.gROOT.GetClass(t)) for t in types]):
                     objects.append(path + str(key.GetName()))
-                    break
         if clsname == "TDirectoryFile":
             # recursively enter lower directory levels
             list_objects_recursive(<TDirectory*> rdir.Get(key.GetName()),

--- a/root_numpy/src/tree.pyx
+++ b/root_numpy/src/tree.pyx
@@ -10,8 +10,14 @@ cdef list_objects_recursive(TDirectory* rdir, objects, types=None, path=""):
     for i in range(nkeys):
         key = <TKey*> keys.At(i)
         clsname = str(key.GetClassName())
-        if types is None or clsname in types:
+        cl = ROOT.gROOT.GetClass(clsname)
+        if types is None:
             objects.append(path + str(key.GetName()))
+        else:
+            for t in types:
+                if cl.InheritsFrom(ROOT.gROOT.GetClass(t)):
+                    objects.append(path + str(key.GetName()))
+                    break
         if clsname == "TDirectoryFile":
             # recursively enter lower directory levels
             list_objects_recursive(<TDirectory*> rdir.Get(key.GetName()),


### PR DESCRIPTION
following the check in [rootls](root-mirror/root/blob/master/main/python/cmdLineUtils.py#L186), check not only for exact class matches but also inheritance.
This catches the corner cases of e.g. TNtupleD