### PR TITLE
disable building of TMVA interface if NOTMVA is set

### DIFF
--- a/root_numpy/info.py
+++ b/root_numpy/info.py
@@ -6,5 +6,5 @@
 |_|  \___/ \___/ \__|___|_| |_|\__,_|_| |_| |_| .__/ \__, |  {0}
                    |_____|                    |_|    |___/
 """
-__version__ = '4.5.0.dev0'
+__version__ = '4.5.1.dev0'
 __doc__ = __doc__.format(__version__)  # pylint:disable=redefined-builtin

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ packages = [
     'root_numpy.extern',
     ]
 
-if has_tmva:
+if has_tmva and not os.getenv('NOTMVA', None):
     librootnumpy_tmva = Extension(
         'root_numpy.tmva._libtmvanumpy',
         sources=[


### PR DESCRIPTION
xref #256 

``NOTMVA=1 pip install root_numpy``

This is a temporary solution until we can handle their new DataLoader interface in TMVA