### PR TITLE
rec2array: handle fixed-length 1D array fields

### DIFF
--- a/root_numpy/_utils.py
+++ b/root_numpy/_utils.py
@@ -26,7 +26,7 @@ def rec2array(rec, fields=None):
         A NumPy structured array that will be cast into a homogenous data type.
     fields : list of strings, optional (default=None)
         The fields to include as columns in the output array. If None, then all
-        columns will be included.
+        columns will be included. All fields must have the same shape.
 
     Returns
     -------
@@ -38,8 +38,8 @@ def rec2array(rec, fields=None):
         fields = rec.dtype.names
     if len(fields) == 1:
         return rec[fields[0]]
-    # Creates a copy and recasts data to a consistent datatype
-    return np.vstack([rec[field] for field in fields]).T
+    # Creates a copy and casts all data to the same type
+    return np.squeeze(np.dstack([rec[field] for field in fields]))
 
 
 def stack(recs, fields=None):

--- a/root_numpy/_utils.py
+++ b/root_numpy/_utils.py
@@ -33,6 +33,53 @@ def rec2array(rec, fields=None):
     array : NumPy ndarray
         A new NumPy ndarray with homogeneous data types for all columns.
 
+    Notes
+    -----
+    If the fields are scalars the shape of the output ``array`` will be
+    ``(len(rec), num_fields)``. If the fields are arrays of length
+    ``num_things`` the shape of the output ``array`` will be ``(len(rec),
+    num_things, num_fields)``.
+
+    Examples
+    --------
+
+    >>> from root_numpy import rec2array
+    >>> import numpy as np
+    >>> a = np.array([
+    ...         (12345, 2., 2.1, True),
+    ...         (3, 4., 4.2, False),],
+    ...         dtype=[
+    ...             ('x', np.int32),
+    ...             ('y', np.float32),
+    ...             ('z', np.float64),
+    ...             ('w', np.bool)])
+    >>> arr = rec2array(a)
+    >>> arr
+    array([[  1.23450000e+04,   2.00000000e+00,   2.10000000e+00,
+              1.00000000e+00],
+           [  3.00000000e+00,   4.00000000e+00,   4.20000000e+00,
+              0.00000000e+00]])
+    >>> arr.dtype
+    dtype('float64')
+    >>>
+    >>> a = np.array([
+    ...         ([1, 2, 3], [4.5, 6, 9.5],),
+    ...         ([4, 5, 6], [3.3, 7.5, 8.4],),],
+    ...         dtype=[
+    ...             ('x', np.int32, (3,)),
+    ...             ('y', np.float32, (3,))])
+    >>> arr = rec2array(a)
+    >>> arr
+    array([[[ 1.        ,  4.5       ],
+            [ 2.        ,  6.        ],
+            [ 3.        ,  9.5       ]],
+    <BLANKLINE>
+           [[ 4.        ,  3.29999995],
+            [ 5.        ,  7.5       ],
+            [ 6.        ,  8.39999962]]])
+    >>> arr.shape
+    (2, 3, 2)
+
     """
     if fields is None:
         fields = rec.dtype.names

--- a/root_numpy/_utils.py
+++ b/root_numpy/_utils.py
@@ -18,7 +18,7 @@ VLEN = np.vectorize(len)
 
 
 def rec2array(rec, fields=None):
-    """Convert a record array into a ndarray with a homogeneous data type.
+    """Convert a record/structured array into an ndarray with a homogeneous data type.
 
     Parameters
     ----------
@@ -153,7 +153,7 @@ def stretch(arr, fields=None, return_indices=False):
     if return_indices:
         idx = np.concatenate(list(map(np.arange, len_array)))
         return ret, idx
-    
+
     return ret
 
 

--- a/root_numpy/tests.py
+++ b/root_numpy/tests.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 
 import numpy as np
 from numpy.lib import recfunctions
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 from numpy.random import RandomState
 
 import ROOT
@@ -903,6 +903,21 @@ def test_rec2array():
     arr = rnp.rec2array(a, fields=['x'])
     assert_equal(arr.ndim, 1)
     assert_equal(arr.shape, (a.shape[0],))
+    # array fields
+    a = np.array([
+        ([1, 2, 3], [4.5, 6, 9.5],),
+        ([4, 5, 6], [3.3, 7.5, 8.4],),],
+        dtype=[
+            ('x', np.int32, (3,)),
+            ('y', np.float32, (3,))])
+    arr = rnp.rec2array(a)
+    assert_array_almost_equal(arr,
+        np.array([[[1, 4.5],
+                   [2, 6,],
+                   [3, 9.5]],
+                  [[4, 3.3],
+                   [5, 7.5],
+                   [6, 8.4]]]))
 
 
 def test_stack():


### PR DESCRIPTION
If the fields are scalars the shape of the output array will be ``(len(rec), num_fields)``. If the fields are arrays of length ``num_things`` the shape of the output array will be ``(len(rec), num_things, num_fields)``. 

```python
    >>> from root_numpy import rec2array                                        
    >>> import numpy as np                                                      
    >>> a = np.array([                                                          
    ...         (12345, 2., 2.1, True),                                         
    ...         (3, 4., 4.2, False),],                                          
    ...         dtype=[                                                         
    ...             ('x', np.int32),                                            
    ...             ('y', np.float32),                                          
    ...             ('z', np.float64),                                          
    ...             ('w', np.bool)])                                            
    >>> arr = rec2array(a)                                                      
    >>> arr                                                                     
    array([[  1.23450000e+04,   2.00000000e+00,   2.10000000e+00,               
              1.00000000e+00],                                                  
           [  3.00000000e+00,   4.00000000e+00,   4.20000000e+00,               
              0.00000000e+00]])                                                 
    >>> arr.dtype                                                               
    dtype('float64')                                                            
    >>>                                                                         
    >>> a = np.array([                                                          
    ...         ([1, 2, 3], [4.5, 6, 9.5],),                                    
    ...         ([4, 5, 6], [3.3, 7.5, 8.4],),],                                
    ...         dtype=[                                                         
    ...             ('x', np.int32, (3,)),                                      
    ...             ('y', np.float32, (3,))])                                   
    >>> arr = rec2array(a)                                                      
    >>> arr                                                                     
    array([[[ 1.        ,  4.5       ],                                         
            [ 2.        ,  6.        ],                                         
            [ 3.        ,  9.5       ]],                                        
                                                           
           [[ 4.        ,  3.29999995],                                         
            [ 5.        ,  7.5       ],                                         
            [ 6.        ,  8.39999962]]])                                       
    >>> arr.shape                                                               
    (2, 3, 2)
```