### PR TITLE
Improved hist2array()

### DIFF
--- a/root_numpy/_hist.py
+++ b/root_numpy/_hist.py
@@ -266,9 +266,9 @@ def hist2array(hist, include_overflow=False, copy=True, return_edges=False):
             if return_edges:
                 return np.copy(array), bin_array
             return np.copy(array)
-        if return_edges:
-            return array, bin_array
-        return array
+    if return_edges:
+        return array, bin_array
+    return array
 
 
 def array2hist(array, hist):

--- a/root_numpy/_hist.py
+++ b/root_numpy/_hist.py
@@ -129,7 +129,7 @@ def fill_profile(profile, array, weights=None, return_indices=False):
         "ROOT.TProfile, ROOT.TProfile2D, or ROOT.TProfile3D")
 
 
-def hist2array(hist, include_overflow=False, copy=True):
+def hist2array(hist, include_overflow=False, copy=True, return_edges=False):
     """Convert a ROOT histogram into a NumPy array
 
     Parameters
@@ -143,13 +143,16 @@ def hist2array(hist, include_overflow=False, copy=True):
         If True (the default) then copy the underlying array, otherwise the
         NumPy array will view (and not own) the same memory as the ROOT
         histogram's array.
+    return_edges : bool, optional (default=False)
+        If True then return a list of arrays containing the histogram bin low edges ([x,y,z])
 
     Returns
     -------
-    bin_array[dim]: list of numpy arrays
-        A list of NumPy arrays containing the histogram bin low edges ([x,y,z])
     array : numpy array
         A NumPy array containing the histogram bin values
+    bin_array[dim]: list of numpy arrays
+        If ``return_edges`` is True, then return a list of NumPy arrays containing the histogram bin low edges ([x,y,z])
+
 
     Raises
     ------
@@ -260,8 +263,12 @@ def hist2array(hist, include_overflow=False, copy=True):
         # Preserve x, y, z -> axis 0, 1, 2 order
         array = np.transpose(array)
         if copy:
-            return bin_array, np.copy(array)
-    return bin_array, array
+            if return_edges:
+                return np.copy(array), bin_array
+            return np.copy(array)
+        if return_edges:
+            return array, bin_array
+        return array
 
 
 def array2hist(array, hist):

--- a/root_numpy/_hist.py
+++ b/root_numpy/_hist.py
@@ -210,21 +210,36 @@ def hist2array(hist, include_overflow=False, copy=True):
             array = array_func(ROOT.AsCObject(hist))
             array.shape = shape
             bin_array = [[] for idim in range(array.ndim)]
-            for idim in range(array.ndim):
-              nbins = hist.GetAxis(dim).GetNbins()
-              bin_array[idim] = np.zeros(nbins, dtype=float)
-              for ibin in range(nbins):
-                bin_array[idim][ibin] =  hist.GetAxis(idim).GetBinLowEdge(ibin)
+            if array.ndim > 0:
+                bin_array[0] = np.zeros(shape[0], dtype=float)
+                for ibin in range(shape[0]):
+                    bin_array[0][ibin] =  hist.GetXaxis().GetBinLowEdge(ibin)
+            if array.ndim > 1:
+                bin_array[1] = np.zeros(shape[1], dtype=float)
+                for ibin in range(shape[1]):
+                    bin_array[1][ibin] =  hist.GetYaxis().GetBinLowEdge(ibin)
+            if array.ndim > 2:
+                bin_array[2] = np.zeros(shape[2], dtype=float)
+                for ibin in range(shape[2]):
+                    bin_array[2][ibin] =  hist.GetZaxis().GetBinLowEdge(ibin)
+
         else:
             dtype = np.dtype(DTYPE_ROOT2NUMPY[hist_type])
             array = np.ndarray(shape=shape, dtype=dtype,
                                buffer=hist.GetArray())
             bin_array = [[] for idim in range(array.ndim)]
-            for idim in range(array.ndim):
-              nbins = hist.GetAxis(dim).GetNbins()
-              bin_array[idim] = np.zeros(nbins, dtype=float)
-              for ibin in range(nbins):
-                bin_array[idim][ibin] =  hist.GetAxis(idim).GetBinLowEdge(ibin)
+            if array.ndim > 0:
+                bin_array[0] = np.zeros(shape[0], dtype=float)
+                for ibin in range(shape[0]):
+                    bin_array[0][ibin] =  hist.GetXaxis().GetBinLowEdge(ibin)
+            if array.ndim > 1:
+                bin_array[1] = np.zeros(shape[1], dtype=float)
+                for ibin in range(shape[1]):
+                    bin_array[1][ibin] =  hist.GetYaxis().GetBinLowEdge(ibin)
+            if array.ndim > 2:
+                bin_array[2] = np.zeros(shape[2], dtype=float)
+                for ibin in range(shape[2]):
+                    bin_array[2][ibin] =  hist.GetZaxis().GetBinLowEdge(ibin)
 
     else:  # THn THnSparse
         dtype = np.dtype(DTYPE_ROOT2NUMPY[hist_type])
@@ -239,13 +254,13 @@ def hist2array(hist, include_overflow=False, copy=True):
         # Remove overflow and underflow bins
         array = array[tuple([slice(1, -1) for idim in range(array.ndim)])]
         for idim in range(array.ndim):
-            bin_array[idim] = bin_array[tuple(slice(1, -1))]
+            bin_array[idim] = bin_array[idim][slice(1, -1)]
 
     if simple_hist:
         # Preserve x, y, z -> axis 0, 1, 2 order
         array = np.transpose(array)
         if copy:
-            return np.copy(array)
+            return bin_array, np.copy(array)
     return bin_array, array
 
 

--- a/root_numpy/src/hist.pyx
+++ b/root_numpy/src/hist.pyx
@@ -175,9 +175,15 @@ def thn2array(hist, shape, dtype):
     cdef long long nbins = _hist.GetNbins()
     cdef np.ndarray array = np.zeros(shape, dtype=dtype)
     cdef np.ndarray array_ravel_view = np.ravel(array)
+    cdef bin_array = [[] for idim in range(array.ndim)]
     for ibin in range(nbins):
         array_ravel_view[ibin] = _hist.GetBinContent(ibin)
-    return array
+    for idim in range(array.ndim):
+      nbins = _hist.GetAxis(dim).GetNbins()
+      bin_array[idim] = np.zeros(nbins, dtype=float)
+      for ibin in range(nbins):
+        bin_array[idim][ibin] =  _hist.GetAxis(idim).GetBinLowEdge(ibin)
+    return bin_array,array
 
 
 @cython.boundscheck(False)
@@ -189,8 +195,14 @@ def thnsparse2array(hist, shape, dtype):
     cdef long long nbins = _hist.GetNbins()
     cdef np.ndarray array = np.zeros(shape, dtype=dtype)
     cdef np.ndarray coord = np.empty(array.ndim, dtype=np.int32)
+    cdef bin_array = [[] for idim in range(array.ndim)]
     itemset = array.itemset
     for ibin in range(nbins):
         content = _hist.GetBinContent(ibin, <int*> coord.data)
         itemset(tuple(coord), content)
-    return array
+    for idim in range(array.ndim):
+      nbins = _hist.GetAxis(dim).GetNbins()
+      bin_array[idim] = np.zeros(nbins, dtype=float)
+      for ibin in range(nbins):
+        bin_array[idim][ibin] =  _hist.GetAxis(idim).GetBinLowEdge(ibin)
+    return bin_array,array


### PR DESCRIPTION
One thing I've always found problematic is to plot a TH object in pyplot via hist2array because I don't have access to the array of bin low edges. I've made a small fix. Now the hist2array function returns two arguments.

```
    bin_array[dim]: list of numpy arrays
        A list of NumPy arrays containing the histogram bin low edges ([x,y,z])
    array : numpy array
        A NumPy array containing the histogram bin values
```

The dimension of bin_array depends on the dimension of the histogram.

This is my first pull request ever, so I deeply apologize if I have done something wrong or not according to the rules. Every suggestion, comment or proposition is extremely welcome.
