### PR TITLE
[MRG] numpy dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,9 @@ setup(
         'root_numpy': ['testdata/*.root', 'config.json'],
     },
     ext_modules=ext_modules,
+    extras_require={
+        'with-numpy': ('numpy',),
+    },
     zip_safe=False,
     classifiers=[
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
* Add numpy to setup's extras_require to make explicit dependency optional:
Useful for a requirements.txt file with root_numpy[with-numpy]. Exactly how scikit-learn implements optional explicit dependency on numpy in setup.py: http://scikit-learn.org/stable/install.html

* Put numpy in setup's setup_requires and install_requires lists only if not already installed.
Prevents pip from upgrading an existing numpy installation.
This is what scipy does.